### PR TITLE
remove all import-alls

### DIFF
--- a/examples/bmode_reconstruction_example.py
+++ b/examples/bmode_reconstruction_example.py
@@ -1,12 +1,14 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
 import scipy.io
 
 from example_utils import download_from_gdrive_if_does_not_exist
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
-from kwave.ktransducer import *
+from kwave.ktransducer import NotATransducer, kWaveTransducerSimple
 from kwave.reconstruction.beamform import beamform
 from kwave.reconstruction.converter import build_channel_data
 from kwave.utils.dotdictionary import dotdict
@@ -169,7 +171,8 @@ if __name__ == '__main__':
                 'pml_size': [PML_X_SIZE, PML_Y_SIZE, PML_Z_SIZE],
                 'data_cast': DATA_CAST,
                 'data_recast': True,
-                'save_to_disk': input_file_full_path,
+                'save_to_disk': True,
+                'input_filename': input_file_full_path,
                 'save_to_disk_exit': False,
             }
 

--- a/kwave/kWaveSimulation.py
+++ b/kwave/kWaveSimulation.py
@@ -1,7 +1,12 @@
+from dataclasses import dataclass
 from warnings import warn
 
-from kwave.kWaveSimulation_helper import *
-from kwave.kgrid import *
+import numpy as np
+
+from kwave.data import Array
+from kwave.kWaveSimulation_helper import display_simulation_params, set_sound_speed_ref, expand_grid_matrices, \
+    create_storage_variables, create_absorption_variables, scale_source_terms_func
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource

--- a/kwave/kspaceFirstOrder.py
+++ b/kwave/kspaceFirstOrder.py
@@ -4,7 +4,9 @@ from operator import itemgetter
 from tempfile import gettempdir
 from warnings import warn
 
-from kwave.ktransducer import *
+import numpy as np
+
+from kwave.ksensor import kSensor
 from kwave.utils.checks import is_unix
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.io import get_date_string

--- a/kwave/kspaceFirstOrder2D.py
+++ b/kwave/kspaceFirstOrder2D.py
@@ -1,11 +1,14 @@
+import os
 import tempfile
 
+import numpy as np
 from numpy.fft import ifftshift
 
 from kwave.executor import Executor
 from kwave.kWaveSimulation import kWaveSimulation
 from kwave.kWaveSimulation_helper import retract_transducer_grid_size, save_to_disk_func
-from kwave.kspaceFirstOrder import *
+from kwave.kspaceFirstOrder import kspaceFirstOrderC, kspaceFirstOrderG
+from kwave.utils.dotdictionary import dotdict
 from kwave.utils.interp import interpolate2d
 from kwave.utils.pml import get_pml
 from kwave.utils.tictoc import TicToc

--- a/kwave/kspaceFirstOrder3D.py
+++ b/kwave/kspaceFirstOrder3D.py
@@ -1,7 +1,10 @@
+import numpy as np
+
 from kwave.executor import Executor
 from kwave.kWaveSimulation import kWaveSimulation
 from kwave.kWaveSimulation_helper import retract_transducer_grid_size, save_to_disk_func
-from kwave.kspaceFirstOrder import *
+from kwave.kspaceFirstOrder import kspaceFirstOrderC, kspaceFirstOrderG
+from kwave.utils.dotdictionary import dotdict
 from kwave.utils.interp import interpolate3d
 from kwave.utils.pml import get_pml
 from kwave.utils.tictoc import TicToc

--- a/kwave/kspaceFirstOrderAS.py
+++ b/kwave/kspaceFirstOrderAS.py
@@ -1,13 +1,17 @@
+import os
 import tempfile
 
+import numpy as np
 from numpy.fft import ifftshift
 
+from kwave import kWaveGrid
 from kwave.enums import DiscreteCosine
 from kwave.executor import Executor
 from kwave.kWaveSimulation import kWaveSimulation
 from kwave.kWaveSimulation_helper import retract_transducer_grid_size, save_to_disk_func
-from kwave.kspaceFirstOrder import *
+from kwave.kspaceFirstOrder import kspaceFirstOrderC
 from kwave.utils.checks import num_dim2
+from kwave.utils.dotdictionary import dotdict
 from kwave.utils.interp import interpolate2d
 from kwave.utils.math import sinc
 from kwave.utils.pml import get_pml

--- a/tests/matlab_test_data_collectors/python_testers/h5io_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/h5io_test.py
@@ -1,6 +1,10 @@
-from kwave.utils.io import *
-import numpy as np
+import os
 from pathlib import Path
+
+import h5py
+import numpy as np
+
+from kwave.utils.io import write_matrix, write_attributes, write_grid, write_flags
 
 
 def compare_h5_attributes(local_h5_path, ref_path):

--- a/tests/test_cpp_io_in_parts.py
+++ b/tests/test_cpp_io_in_parts.py
@@ -28,8 +28,8 @@ def test_cpp_io_in_parts():
     example_number = 1
 
     # input and output filenames (these must have the .h5 extension)
-    input_filename = 'out_cpp_io_in_parts.h5'
-    output_filename = 'out_cpp_io_in_parts.h5'
+    input_filename = 'out_cpp_io_in_parts_input.h5'
+    output_filename = 'out_cpp_io_in_parts_ouput.h5'
 
     # pathname for the input and output files
     pathname = gettempdir()

--- a/tests/test_cpp_io_in_parts.py
+++ b/tests/test_cpp_io_in_parts.py
@@ -28,8 +28,8 @@ def test_cpp_io_in_parts():
     example_number = 1
 
     # input and output filenames (these must have the .h5 extension)
-    input_filename  = 'example_input.h5'
-    output_filename = 'example_output.h5'
+    input_filename = 'out_cpp_io_in_parts.h5'
+    output_filename = 'out_cpp_io_in_parts.h5'
 
     # pathname for the input and output files
     pathname = gettempdir()

--- a/tests/test_ivp_3D_simulation.py
+++ b/tests/test_ivp_3D_simulation.py
@@ -9,18 +9,20 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
-from kwave.ktransducer import *
+from kwave.ktransducer import kSensor
 from kwave.utils.mapgen import make_ball
 from tests.diff_utils import compare_against_ref
 
 
 def test_ivp_3D_simulation():
-
     # =========================================================================
     # SIMULATION
     # =========================================================================

--- a/tests/test_ivp_axisymmetric_simulation.py
+++ b/tests/test_ivp_axisymmetric_simulation.py
@@ -9,12 +9,15 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrderAS import kspaceFirstOrderASC
-from kwave.ktransducer import *
 from kwave.utils.mapgen import make_disc
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_ivp_binary_sensor_mask.py
+++ b/tests/test_ivp_binary_sensor_mask.py
@@ -10,18 +10,20 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
+from kwave.ktransducer import kSensor
 from kwave.utils.mapgen import make_disc, make_circle
 from tests.diff_utils import compare_against_ref
 
 
 def test_ivp_binary_sensor_mask():
-
     # create the computational grid
     Nx = 128  # number of grid points in the x (row) direction
     Ny = 128  # number of grid points in the y (column) direction

--- a/tests/test_ivp_comparison_modelling_functions.py
+++ b/tests/test_ivp_comparison_modelling_functions.py
@@ -12,10 +12,11 @@ from tempfile import gettempdir
 
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.interp import cart2grid
 from kwave.utils.mapgen import make_disc, make_cart_circle
 from tests.diff_utils import compare_against_ref

--- a/tests/test_ivp_heterogeneous_medium.py
+++ b/tests/test_ivp_heterogeneous_medium.py
@@ -10,12 +10,15 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.mapgen import make_disc, make_cart_circle
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_ivp_homogeneous_medium.py
+++ b/tests/test_ivp_homogeneous_medium.py
@@ -12,43 +12,44 @@ from tempfile import gettempdir
 
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.mapgen import make_disc, make_cart_circle
 from tests.diff_utils import compare_against_ref
 
 
 def test_ivp_homogeneous_medium():
     # create the computational grid
-    Nx = 128           # number of grid points in the x (row) direction
-    Ny = 128           # number of grid points in the y (column) direction
-    dx = 0.1e-3        # grid point spacing in the x direction [m]
-    dy = 0.1e-3        # grid point spacing in the y direction [m]
+    Nx = 128  # number of grid points in the x (row) direction
+    Ny = 128  # number of grid points in the y (column) direction
+    dx = 0.1e-3  # grid point spacing in the x direction [m]
+    dy = 0.1e-3  # grid point spacing in the y direction [m]
     kgrid = kWaveGrid([Nx, Ny], [dx, dy])
 
     # define the properties of the propagation medium
     medium = kWaveMedium(sound_speed=1500, alpha_coeff=0.75, alpha_power=1.5)
 
     # create initial pressure distribution using make_disc
-    disc_magnitude = 5 # [Pa]
-    disc_x_pos = 50    # [grid points]
-    disc_y_pos = 50    # [grid points]
-    disc_radius = 8    # [grid points]
+    disc_magnitude = 5  # [Pa]
+    disc_x_pos = 50  # [grid points]
+    disc_y_pos = 50  # [grid points]
+    disc_radius = 8  # [grid points]
     disc_1 = disc_magnitude * make_disc(Nx, Ny, disc_x_pos, disc_y_pos, disc_radius)
 
-    disc_magnitude = 3 # [Pa]
-    disc_x_pos = 80    # [grid points]
-    disc_y_pos = 60    # [grid points]
-    disc_radius = 5    # [grid points]
+    disc_magnitude = 3  # [Pa]
+    disc_x_pos = 80  # [grid points]
+    disc_y_pos = 60  # [grid points]
+    disc_radius = 5  # [grid points]
     disc_2 = disc_magnitude * make_disc(Nx, Ny, disc_x_pos, disc_y_pos, disc_radius)
 
     source = kSource()
     source.p0 = disc_1 + disc_2
 
     # define a centered circular sensor
-    sensor_radius = 4e-3   # [m]
+    sensor_radius = 4e-3  # [m]
     num_sensor_points = 50
     sensor_mask = make_cart_circle(sensor_radius, num_sensor_points)
     sensor = kSensor(sensor_mask)

--- a/tests/test_ivp_loading_external_image.py
+++ b/tests/test_ivp_loading_external_image.py
@@ -10,12 +10,15 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.io import load_image
 from kwave.utils.mapgen import make_cart_circle
 from tests.diff_utils import compare_against_ref

--- a/tests/test_ivp_photoacoustic_waveforms.py
+++ b/tests/test_ivp_photoacoustic_waveforms.py
@@ -10,13 +10,16 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
-from kwave.ktransducer import *
 from kwave.utils.mapgen import make_ball, make_disc
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_ivp_sensor_frequency_response.py
+++ b/tests/test_ivp_sensor_frequency_response.py
@@ -10,12 +10,15 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.mapgen import make_disc, make_cart_circle
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_kutils.py
+++ b/tests/test_kutils.py
@@ -1,5 +1,8 @@
-from kwave import kWaveMedium
-from kwave.ktransducer import *
+import numpy as np
+
+from kwave.kgrid import kWaveGrid
+from kwave.kmedium import kWaveMedium
+from kwave.ktransducer import kWaveTransducerSimple, NotATransducer
 from kwave.reconstruction.beamform import focus
 from kwave.utils.checks import check_stability
 from kwave.utils.dotdictionary import dotdict

--- a/tests/test_na_controlling_the_PML.py
+++ b/tests/test_na_controlling_the_PML.py
@@ -12,10 +12,11 @@ from tempfile import gettempdir
 
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.mapgen import make_disc, make_cart_circle
 from tests.diff_utils import compare_against_ref
 
@@ -65,7 +66,7 @@ def test_na_controlling_the_pml():
     sensor = kSensor(sensor_mask)
 
     # Example 1
-    input_filename = f'example_ivp_cont_pml_input.h5'
+    input_filename = f'input_1.h5'
     pathname = gettempdir()
     input_file_full_path = os.path.join(pathname, input_filename)
     input_args = {

--- a/tests/test_pr_2D_FFT_line_sensor.py
+++ b/tests/test_pr_2D_FFT_line_sensor.py
@@ -9,12 +9,15 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.filters import smooth
 from kwave.utils.mapgen import make_disc
 from tests.diff_utils import compare_against_ref

--- a/tests/test_pr_2D_TR_circular_sensor.py
+++ b/tests/test_pr_2D_TR_circular_sensor.py
@@ -9,12 +9,15 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.filters import smooth
 from kwave.utils.io import load_image
 from kwave.utils.mapgen import make_cart_circle

--- a/tests/test_pr_2D_TR_directional_sensors.py
+++ b/tests/test_pr_2D_TR_directional_sensors.py
@@ -10,13 +10,15 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
-from kwave.ksensor import kSensorDirectivity
+from kwave.ksensor import kSensorDirectivity, kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.filters import smooth
 from kwave.utils.mapgen import make_disc
 from tests.diff_utils import compare_against_ref

--- a/tests/test_pr_2D_TR_line_sensor.py
+++ b/tests/test_pr_2D_TR_line_sensor.py
@@ -9,12 +9,15 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.filters import smooth
 from kwave.utils.mapgen import make_disc
 from tests.diff_utils import compare_against_ref

--- a/tests/test_sd_directional_array_elements.py
+++ b/tests/test_sd_directional_array_elements.py
@@ -9,12 +9,15 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.filters import filter_time_series
 from kwave.utils.mapgen import make_circle
 from kwave.utils.matlab import matlab_find, matlab_mask, unflatten_matlab_mask

--- a/tests/test_sd_directivity_modelling_2D.py
+++ b/tests/test_sd_directivity_modelling_2D.py
@@ -10,12 +10,15 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.filters import filter_time_series
 from kwave.utils.interp import cart2grid
 from kwave.utils.mapgen import make_cart_circle

--- a/tests/test_sd_directivity_modelling_3D.py
+++ b/tests/test_sd_directivity_modelling_3D.py
@@ -10,13 +10,16 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
-from kwave.ktransducer import *
-from kwave.utils.filters import *
+from kwave.utils.filters import filter_time_series
 from kwave.utils.interp import cart2grid
 from kwave.utils.mapgen import make_cart_circle
 from kwave.utils.matlab import matlab_find, unflatten_matlab_mask

--- a/tests/test_sd_sensor_directivity_2D.py
+++ b/tests/test_sd_sensor_directivity_2D.py
@@ -10,13 +10,15 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
-from kwave.ksensor import kSensorDirectivity
+from kwave.ksensor import kSensorDirectivity, kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from tests.diff_utils import compare_against_ref
 
 

--- a/tests/test_tvsp_doppler_effect.py
+++ b/tests/test_tvsp_doppler_effect.py
@@ -10,12 +10,15 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.filters import filter_time_series
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_tvsp_homogeneous_medium_monopole.py
+++ b/tests/test_tvsp_homogeneous_medium_monopole.py
@@ -9,12 +9,15 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
-from kwave.ktransducer import *
 from kwave.utils.filters import filter_time_series
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_us_beam_patterns.py
+++ b/tests/test_us_beam_patterns.py
@@ -9,11 +9,15 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
-from kwave.ktransducer import *
+from kwave.ktransducer import kWaveTransducerSimple, NotATransducer
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.signals import tone_burst
 from tests.diff_utils import compare_against_ref

--- a/tests/test_us_bmode_linear_transducer.py
+++ b/tests/test_us_bmode_linear_transducer.py
@@ -9,11 +9,14 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
-from kwave.ktransducer import *
+from kwave.ktransducer import kWaveTransducerSimple, NotATransducer
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.mapgen import make_ball
 from kwave.utils.signals import tone_burst

--- a/tests/test_us_defining_transducer.py
+++ b/tests/test_us_defining_transducer.py
@@ -9,11 +9,15 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
-from kwave.ktransducer import *
+from kwave.ktransducer import kWaveTransducerSimple, NotATransducer
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.signals import tone_burst
 from tests.diff_utils import compare_against_ref

--- a/tests/test_us_transducer_as_sensor.py
+++ b/tests/test_us_transducer_as_sensor.py
@@ -9,12 +9,15 @@
 import os
 from tempfile import gettempdir
 
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
-from kwave.ktransducer import *
+from kwave.ktransducer import kWaveTransducerSimple, NotATransducer
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.mapgen import make_ball
 from kwave.utils.signals import tone_burst


### PR DESCRIPTION
This PR removes all "import all" statements from sub-package files and examples in order to fix import cycles.

closes #73 


