### PR TITLE
Add trim_zeros function and test

### DIFF
--- a/kwave/utils/matrix.py
+++ b/kwave/utils/matrix.py
@@ -8,7 +8,7 @@ from .data import scale_time
 from .tictoc import TicToc
 
 
-def trim_zeros(data: np.ndarray) -> tuple[np.ndarray, list[tuple[int, int]]]:
+def trim_zeros(data: np.ndarray) -> Tuple[np.ndarray, List[Tuple[int, int]]]:
     """
     Create a tight bounding box by removing zeros.
 

--- a/kwave/utils/matrix.py
+++ b/kwave/utils/matrix.py
@@ -8,6 +8,84 @@ from .data import scale_time
 from .tictoc import TicToc
 
 
+def trim_zeros(data: np.ndarray) -> tuple[np.ndarray, list[tuple[int, int]]]:
+    """
+    Create a tight bounding box by removing zeros.
+
+    Args:
+        data: Matrix to trim.
+
+    Returns:
+        Tuple containing the trimmed matrix and indices used to trim the matrix.
+
+    Raises:
+        ValueError: If the input data is not 1D, 2D, or 3D.
+
+    Example:
+        data = np.array([[0, 0, 0, 0, 0, 0],
+                         [0, 0, 0, 3, 0, 0],
+                         [0, 0, 1, 3, 4, 0],
+                         [0, 0, 1, 3, 4, 0],
+                         [0, 0, 1, 3, 0, 0],
+                         [0, 0, 0, 0, 0, 0]])
+
+        trimmed_data, indices = trim_zeros(data)
+
+        # Output:
+        # trimmed_data:
+        # [[0 3 0]
+        #  [1 3 4]
+        #  [1 3 4]
+        #  [1 3 0]]
+        #
+        # indices:
+        # [(1, 4), (2, 5), (3, 5)]
+
+    """
+    data = np.squeeze(data)
+
+    # only allow 1D, 2D, and 3D
+    if data.ndim > 3:
+        raise ValueError("Input data must be 1D, 2D, or 3D.")
+
+    # set collapse directions for each dimension
+    collapse = {2: [1, 0], 3: [(1, 2), (0, 2), (0, 1)]}
+
+    # preallocate output to store indices
+    ind = []
+
+    # loop through dimensions
+    for dim_index in range(data.ndim):
+
+        # collapse to 1D vector
+        if data.ndim == 1:
+            summed_values = data
+        else:
+            summed_values = np.sum(np.abs(data), axis=collapse[data.ndim][dim_index])
+
+        # find the first and last non-empty values
+        non_zeros = np.where(summed_values > 0)[0]
+        ind_first = non_zeros[0]
+        ind_last = non_zeros[-1] + 1
+
+        # trim data
+        if data.ndim == 1:
+            data = data[ind_first:ind_last]
+            ind.append((ind_first, ind_last))
+        else:
+            if dim_index == 0:
+                data = data[ind_first:ind_last, ...]
+                ind.append((ind_first, ind_last))
+            elif dim_index == 1:
+                data = data[:, ind_first:ind_last, ...]
+                ind.append((ind_first, ind_last))
+            elif dim_index == 2:
+                data = data[..., ind_first:ind_last]
+                ind.append((ind_first, ind_last))
+
+    return data, ind
+
+
 def expand_matrix(matrix, exp_coeff, edge_val=None):
     """
     Enlarge a matrix by extending the edge values.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -306,6 +306,25 @@ def test_trim_zeros():
     assert np.all(mat_trimmed == np.ones([5, 5, 5])), "trim_zeros did not pass the 3D test."
     assert ind == [(3, 8), (3, 8), (3, 8)], "trim_zeros did not return the correct indices for the 3D case."
 
+    # Harder 2D test case
+
+    data = np.array([[0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 3, 0, 0],
+                     [0, 0, 1, 3, 4, 0],
+                     [0, 0, 1, 3, 4, 0],
+                     [0, 0, 1, 3, 0, 0],
+                     [0, 0, 0, 0, 0, 0]])
+
+    correct_trimmed = np.array([[0, 3, 0],
+                                [1, 3, 4],
+                                [1, 3, 4],
+                                [1, 3, 0]])
+
+    data_trimmed, ind = trim_zeros(data)
+
+    # assert correctness
+    assert np.all(data_trimmed == correct_trimmed), "trim_zeros did not pass the hard 2D test."
+
     # Higher dimensional case (4D)
     mat = np.zeros([10, 10, 10, 10])
     mat[3:8, 3:8, 3:8, 3:8] = 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from kwave.utils.conversion import db2neper, neper2db
 from kwave.utils.filters import extract_amp_phase, spect, apply_filter
 from kwave.utils.interp import get_bli
 from kwave.utils.mapgen import fit_power_law_params, power_law_kramers_kronig
-from kwave.utils.matrix import gradient_fd, resize, num_dim
+from kwave.utils.matrix import gradient_fd, resize, num_dim, trim_zeros
 from kwave.utils.signals import tone_burst, add_noise, gradient_spect
 from tests.matlab_test_data_collectors.python_testers.utils.record_reader import TestRecordReader
 
@@ -282,3 +282,34 @@ def test_resize_2D_nearest_smaller():
     p1 = resize(p0, new_size, interp_mode='nearest')
     assert p1.shape == tuple(new_size)
     assert np.all(p1.T == [0., 1.])
+
+
+def test_trim_zeros():
+    # 1D case
+    vec = np.zeros([10])
+    vec[3:8] = 1
+    vec_trimmed, ind = trim_zeros(vec)
+    assert np.all(vec_trimmed == np.ones([5])), "trim_zeros did not pass the 1D test."
+    assert ind == [(3, 8)], "trim_zeros did not return the correct indices for the 1D case."
+
+    # 2D case
+    mat = np.zeros([10, 10])
+    mat[3:8, 3:8] = 1
+    mat_trimmed, ind = trim_zeros(mat)
+    assert np.all(mat_trimmed == np.ones([5, 5])), "trim_zeros did not pass the 2D test."
+    assert ind == [(3, 8), (3, 8)], "trim_zeros did not return the correct indices for the 2D case."
+
+    # 3D case
+    mat = np.zeros([10, 10, 10])
+    mat[3:8, 3:8, 3:8] = 1
+    mat_trimmed, ind = trim_zeros(mat)
+    assert np.all(mat_trimmed == np.ones([5, 5, 5])), "trim_zeros did not pass the 3D test."
+    assert ind == [(3, 8), (3, 8), (3, 8)], "trim_zeros did not return the correct indices for the 3D case."
+
+    # Higher dimensional case (4D)
+    mat = np.zeros([10, 10, 10, 10])
+    mat[3:8, 3:8, 3:8, 3:8] = 1
+    with pytest.raises(ValueError):
+        mat_trimmed, ind = trim_zeros(mat)
+
+    # TODO: generalize to N-D case


### PR DESCRIPTION
Addresses #127 

Adds Python implementation of the trim_zero function (introduced in kWave 1.4) and test cases.