### PR TITLE
Python implementation of `kWaveArray` & `get_off_grid_points(...)`

### DIFF
--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -15,7 +15,6 @@ VERSION = '0.2.1'
 # is refactored
 
 platform = sys.platform
-platform = 'linux'
 
 if platform.startswith('linux'):
     system = 'linux'

--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -15,6 +15,7 @@ VERSION = '0.2.1'
 # is refactored
 
 platform = sys.platform
+platform = 'linux'
 
 if platform.startswith('linux'):
     system = 'linux'

--- a/kwave/utils/kwave_array.py
+++ b/kwave/utils/kwave_array.py
@@ -75,7 +75,7 @@ class Element:
                 self.end_point = [self.end_point]
             self.end_point = np.array(self.end_point, dtype=float)
 
-        self.measure = float(self.measure)
+        self.measure = round(float(self.measure), 8)
 
 
 class kWaveArray(object):

--- a/kwave/utils/kwave_array.py
+++ b/kwave/utils/kwave_array.py
@@ -719,7 +719,7 @@ def off_grid_points(kgrid, points,
 
     # initialise the source mask
     if mask_only:
-        mask_type = np.bool
+        mask_type = bool
     elif single_precision:
         mask_type = np.float32
     else:

--- a/kwave/utils/kwave_array.py
+++ b/kwave/utils/kwave_array.py
@@ -1,0 +1,729 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from kwave.kgrid import kWaveGrid
+from numpy import arcsin, pi, cos, size, array
+from numpy.linalg import linalg
+from math import ceil
+
+from kwave.utils.conversion import tol_star
+from kwave.utils.interp import get_delta_bli
+from kwave.utils.mapgen import trim_cart_points, make_cart_rect, make_cart_arc
+from kwave.utils.math import sinc
+from kwave.utils.matlab import matlab_assign, matlab_mask
+
+
+@dataclass
+class Element:
+    group_id: int
+    type: str
+    dim: int
+    active: bool
+    measure: float
+
+    group_type: Optional[str] = None
+    element_number: Optional[int] = None
+
+    inner_diameter: Optional[float] = None
+    outer_diameter: Optional[float] = None
+    diameter: Optional[float] = None
+
+    radius_of_curvature: Optional[float] = None
+    position: Optional[np.ndarray] = None
+    focus_position: Optional[np.ndarray] = None
+
+    length: Optional[float] = None
+    width: Optional[float] = None
+    orientation: Optional = None
+
+    start_point: Optional[np.ndarray] = None
+    end_point: Optional[np.ndarray] = None
+
+    def __post_init__(self):
+        """
+        Useful for consistency in tests where expected Matlab values can come in various types
+        Returns:
+            None
+        """
+        if self.position is not None:
+            self.position = np.array(self.position, dtype=float)
+        if self.focus_position is not None:
+            self.focus_position = np.array(self.focus_position, dtype=float)
+        self.active = bool(self.active)
+
+        if self.inner_diameter:
+            self.inner_diameter = float(self.inner_diameter)
+
+        if self.outer_diameter:
+            self.outer_diameter = float(self.outer_diameter)
+
+        if self.diameter:
+            self.diameter = float(self.diameter)
+
+        if self.orientation is not None:
+            self.orientation = np.array(self.orientation, dtype=float)
+
+        if self.start_point is not None:
+            if not (isinstance(self.start_point, list) or isinstance(self.start_point, np.ndarray)):
+                self.start_point = [self.start_point]
+            self.start_point = np.array(self.start_point, dtype=float)
+
+        if self.end_point is not None:
+            if not (isinstance(self.end_point, list) or isinstance(self.end_point, np.ndarray)):
+                self.end_point = [self.end_point]
+            self.end_point = np.array(self.end_point, dtype=float)
+
+        self.measure = float(self.measure)
+
+
+class kWaveArray(object):
+
+    def __init__(self,
+                 axisymmetric: bool = False,
+                 bli_tolerance: float = 0.05,
+                 bli_type: str = 'sinc',
+                 single_precision: bool = False,
+                 upsampling_rate: int = 10):
+        assert 0 <= bli_tolerance <= 1
+        assert bli_type in ['exact', 'sinc']
+
+        self.axisymmetric = axisymmetric
+        self.bli_tolerance = bli_tolerance
+        self.bli_type = bli_type
+        self.single_precision = single_precision
+        self.upsampling_rate = upsampling_rate
+
+        self.elements = []
+        self.number_elements = 0
+        self.number_groups = 0
+        self.dim = 0
+        self.array_transformation = []
+
+        self.use_spiral_disc_points = 0
+        self.num_arc_plot_points = 100
+        self.element_plot_colour = np.array([0, 158, 194], dtype=float) / 255
+
+    def add_annular_array(self, position, radius, diameters, focus_pos):
+
+        assert isinstance(position, (list, tuple)), "'position' must be list or tuple"
+        assert isinstance(radius, (int, float)), "'radius' must be an integer or float"
+        assert isinstance(diameters, (list, tuple)), "'diameters' must be list or tuple"
+        assert isinstance(focus_pos, (list, tuple)), "'focus_pos' must be list or tuple"
+        assert len(position) == 3, "'position' must have 3 elements"
+        assert len(focus_pos) == 3, "'focus_pos' must have 3 elements"
+        assert all(len(i) == 2 for i in diameters), "'diameters' must be a list of lists, each with 2 elements"
+
+        if self.number_elements == 0:
+            self.dim = 3
+
+        if self.dim != 3:
+            raise ValueError(f"3D annular array cannot be added to an array with {self.dim}D elements.")
+
+        annular_array_num_el = size(diameters, 0)
+
+        self.number_groups += 1
+
+        for el_ind in range(annular_array_num_el):
+            self.number_elements += 1
+
+            varphi_min = arcsin(diameters[el_ind][0] / (2 * radius))
+            varphi_max = arcsin(diameters[el_ind][1] / (2 * radius))
+
+            area = 2 * pi * radius ** 2 * (1 - cos(varphi_max)) - 2 * pi * radius ** 2 * (1 - cos(varphi_min))
+
+            element = Element(
+                group_id=self.number_groups,
+                group_type='annular_array',
+                element_number=el_ind + 1,
+                type='annulus',
+                dim=2,
+                position=array(position, dtype=np.uint8),
+                radius_of_curvature=radius,
+                inner_diameter=diameters[el_ind][0],
+                outer_diameter=diameters[el_ind][1],
+                focus_position=array(focus_pos),
+                active=True,
+                measure=area
+            )
+            self.elements.append(element)
+
+    def add_annular_element(self, position, radius, diameters, focus_pos):
+
+        assert isinstance(position, (list, tuple)), "'position' must be list or tuple"
+        assert isinstance(radius, (int, float)), "'radius' must be an integer or float"
+        assert isinstance(diameters, (list, tuple)), "'diameters' must be list or tuple"
+        assert isinstance(focus_pos, (list, tuple)), "'focus_pos' must be list or tuple"
+        assert len(position) == 3, "'position' must have 3 elements"
+        assert len(focus_pos) == 3, "'focus_pos' must have 3 elements"
+        assert len(diameters) == 2, "'diameters' must have 2 elements"
+
+        if self.number_elements == 0:
+            self.dim = 3
+
+        if self.dim != 3:
+            raise ValueError(f"3D annular array cannot be added to an array with {self.dim}D elements.")
+
+        self.number_elements += 1
+
+        varphi_min = arcsin(diameters[0] / (2 * radius))
+        varphi_max = arcsin(diameters[1] / (2 * radius))
+
+        area = 2 * pi * radius ** 2 * (1 - cos(varphi_max)) - 2 * pi * radius ** 2 * (1 - cos(varphi_min))
+
+        self.elements.append(Element(
+            group_id=0,
+            type='annulus',
+            dim=2,
+            position=array(position),
+            radius_of_curvature=radius,
+            inner_diameter=diameters[0],
+            outer_diameter=diameters[1],
+            focus_position=array(focus_pos),
+            active=True,
+            measure=area
+        ))
+
+    def add_bowl_element(self, position, radius, diameter, focus_pos):
+
+        assert isinstance(position, (list, tuple)), "'position' must be list or tuple"
+        assert isinstance(radius, (int, float)), "'radius' must be an integer or float"
+        assert isinstance(diameter, (int, float)), "'diameter' must be an integer or float"
+        assert isinstance(focus_pos, (list, tuple)), "'focus_pos' must be list or tuple"
+        assert len(position) == 3, "'position' must have 3 elements"
+        assert len(focus_pos) == 3, "'focus_pos' must have 3 elements"
+
+        if self.number_elements == 0:
+            self.dim = 3
+
+        if self.dim != 3:
+            raise ValueError(f"3D bowl element cannot be added to an array with {self.dim}D elements.")
+
+        self.number_elements += 1
+
+        varphi_max = arcsin(diameter / (2 * radius))
+
+        area = 2 * pi * radius ** 2 * (1 - cos(varphi_max))
+
+        self.elements.append(Element(
+            group_id=0,
+            type='bowl',
+            dim=2,
+            position=array(position),
+            radius_of_curvature=radius,
+            diameter=diameter,
+            focus_position=array(focus_pos),
+            active=True,
+            measure=area
+        ))
+
+    def add_rect_element(self, position, Lx, Ly, theta):
+
+        assert isinstance(position, (list, tuple)), "'position' must be a list or tuple"
+        assert isinstance(Lx, (int, float)), "'Lx' must be an integer or float"
+        assert isinstance(Ly, (int, float)), "'Ly' must be an integer or float"
+
+        coord_dim = len(position)
+
+        if coord_dim not in [2, 3]:
+            raise ValueError(
+                "Input position for rectangular element must be specified as a 2 (2D) or 3 (3D) element array.")
+
+        if coord_dim == 3:
+            assert isinstance(theta, (list, tuple)) and len(theta) == 3, "'theta' must be a list or tuple of length 3"
+        else:
+            assert isinstance(theta, (int, float)), "'theta' must be an integer or float"
+
+        if self.number_elements == 0:
+            self.dim = coord_dim
+
+        if self.dim != coord_dim:
+            raise ValueError(f"{coord_dim}D rectangular element cannot be added to an array with {self.dim}D elements.")
+
+        self.number_elements += 1
+
+        area = Lx * Ly
+
+        self.elements.append(Element(
+            group_id=0,
+            type='rect',
+            dim=2,
+            position=array(position),
+            length=Lx,
+            width=Ly,
+            orientation=array(theta) if coord_dim == 3 else theta,
+            active=True,
+            measure=area
+        ))
+
+    def add_arc_element(self, position, radius, diameter, focus_pos):
+
+        assert isinstance(position, (list, tuple)), "'position' must be list or tuple"
+        assert isinstance(radius, (int, float)), "'radius' must be an integer or float"
+        assert isinstance(diameter, (int, float)), "'diameter' must be an integer or float"
+        assert isinstance(focus_pos, (list, tuple)), "'focus_pos' must be list or tuple"
+        assert len(position) == 2, "'position' must have 2 elements"
+        assert len(focus_pos) == 2, "'focus_pos' must have 2 elements"
+
+        if self.number_elements == 0:
+            self.dim = 2
+
+        if self.dim != 2:
+            raise ValueError(f"2D arc element cannot be added to an array with {self.dim}D elements.")
+
+        self.number_elements += 1
+
+        varphi_max = arcsin(diameter / (2 * radius))
+
+        length = 2 * radius * varphi_max
+
+        self.elements.append(Element(
+            group_id=0,
+            type='arc',
+            dim=1,
+            position=array(position),
+            radius_of_curvature=radius,
+            diameter=diameter,
+            focus_position=array(focus_pos),
+            active=True,
+            measure=length
+        ))
+
+    def add_disc_element(self, position, diameter, focus_pos=None):
+
+        assert isinstance(position, (list, tuple)), "'position' must be a list or tuple"
+        assert isinstance(diameter, (int, float)), "'diameter' must be an integer or float"
+
+        coord_dim = len(position)
+
+        if coord_dim not in [2, 3]:
+            raise ValueError("Input position for disc element must be specified as a 2 (2D) or 3 (3D) element array.")
+
+        if coord_dim == 3:
+            assert isinstance(focus_pos, (list, tuple)) and len(
+                focus_pos) == 3, "'focus_pos' must be a list or tuple of length 3"
+        else:
+            focus_pos = []
+
+        if self.number_elements == 0:
+            self.dim = coord_dim
+
+        if self.dim != coord_dim:
+            raise ValueError(f"{coord_dim}D disc element cannot be added to an array with {self.dim}D elements.")
+
+        self.number_elements += 1
+
+        area = pi * (diameter / 2) ** 2
+
+        self.elements.append(Element(
+            group_id=0,
+            type='disc',
+            dim=2,
+            position=array(position),
+            diameter=diameter,
+            focus_position=array(focus_pos),
+            active=True,
+            measure=area
+        ))
+
+    def remove_element(self, element_num):
+
+        if element_num > self.number_elements:
+            raise ValueError(f"Cannot remove element {element_num} from array with {self.number_elements} elements.")
+
+        self.elements.pop(element_num)
+
+        self.number_elements -= 1
+
+    def add_line_element(self, start_point, end_point):
+
+        assert isinstance(start_point, (list, tuple)), "'start_point' must be a list or tuple"
+        assert isinstance(end_point, (list, tuple)), "'end_point' must be a list or tuple"
+
+        input_dim = len(start_point)
+
+        if input_dim not in [1, 2, 3]:
+            raise ValueError("Input start_point must have 1 (in 1D), 2 (in 2D), or 3 (in 3D) elements.")
+
+        if input_dim != len(end_point):
+            raise ValueError("Inputs start_point and end_point must have the same number of elements.")
+
+        if self.number_elements == 0:
+            self.dim = input_dim
+
+        if self.dim != input_dim:
+            raise ValueError(f"{input_dim}D line element cannot be added to an array with {self.dim}D elements.")
+
+        self.number_elements += 1
+
+        line_length = linalg.norm(array(end_point) - array(start_point))
+
+        self.elements.append(Element(
+            group_id=0,
+            type='line',
+            dim=1,
+            start_point=array(start_point),
+            end_point=array(end_point),
+            active=True,
+            measure=line_length
+        ))
+
+    def get_element_grid_weights(self, kgrid, element_num):
+        return self.get_off_grid_points(kgrid, element_num, False)
+
+    def get_element_binary_mask(self, kgrid, element_num):
+        return self.get_off_grid_points(kgrid, element_num, True)
+
+    def get_array_grid_weights(self, kgrid):
+        self.check_for_elements()
+
+        grid_weights = np.zeros((kgrid.Nx, kgrid.Ny, max(kgrid.Nz, 1)))
+
+        for ind in range(self.number_elements):
+            grid_weights += self.get_off_grid_points(kgrid, ind, False)
+
+        return grid_weights
+
+    def get_array_binary_mask(self, kgrid):
+        self.check_for_elements()
+
+        mask = np.zeros((kgrid.Nx, kgrid.Ny, max(kgrid.Nz, 1)), dtype=bool)
+
+        for ind in range(self.number_elements):
+            grid_weights = self.get_off_grid_points(kgrid, ind, True)
+            mask |= grid_weights
+
+        return mask
+
+    def check_for_elements(self):
+        if self.number_elements == 0:
+            raise ValueError('Cannot call method on an array with zero elements.')
+
+    def affine(self, vec):
+
+        if self.array_transformation is None:
+            return vec
+
+        # check vector is the correct length
+        if self.dim != len(vec):
+            raise ValueError('Input vector length must match the number of dimensions')
+
+        # apply transformation
+        vec = np.append(vec, [1])
+        vec = np.matmul(self.array_transformation, vec)
+
+    def get_off_grid_points(self, kgrid, element_num, mask_only):
+
+        # check the array has elements
+        self.check_for_elements()
+
+        # check inputs
+        assert isinstance(kgrid, kWaveGrid)
+        assert 0 <= element_num <= self.number_elements - 1
+
+        # compute measure (length/area/volume) in grid squares (assuming dx = dy = dz)
+        m_grid = self.elements[element_num].measure / (kgrid.dx) ** (self.elements[element_num].dim)
+
+        # get number of integration points
+        if self.elements[element_num].type == 'custom':
+            # assign number of integration points directly
+            m_integration = self.elements[element_num].integration_points.shape[1]
+        else:
+            # compute the number of integration points using the upsampling rate
+            m_integration = ceil(m_grid * self.upsampling_rate)
+
+        # compute integration points covering element
+        if self.elements[element_num].type == 'annulus':
+            # compute points using make_cart_spherical_segment
+            integration_points = make_cart_spherical_segment(
+                self.affine(self.elements[element_num].position),
+                self.elements[element_num].radius_of_curvature,
+                self.elements[element_num].inner_diameter,
+                self.elements[element_num].outer_diameter,
+                self.affine(self.elements[element_num].focus_position),
+                m_integration)
+
+        elif self.elements[element_num].type == 'arc':
+            # compute points using make_cart_arc
+            integration_points = make_cart_arc(
+                self.affine(self.elements[element_num].position),
+                self.elements[element_num].radius_of_curvature,
+                self.elements[element_num].diameter,
+                self.affine(self.elements[element_num].focus_position),
+                m_integration)
+
+        elif self.elements[element_num].type == 'bowl':
+            # compute points using make_cart_bowl
+            integration_points = make_cart_bowl(
+                self.affine(self.elements[element_num].position),
+                self.elements[element_num].radius_of_curvature,
+                self.elements[element_num].diameter,
+                self.affine(self.elements[element_num].focus_position),
+                m_integration)
+
+        elif self.elements[element_num].type == 'custom':
+            # directly assign integration points
+            integration_points = self.elements[element_num].integration_points
+
+        elif self.elements[element_num].type == 'disc':
+            # compute points using make_cart_disc
+            integration_points = make_cart_disc(
+                self.affine(self.elements[element_num].position),
+                self.elements[element_num].diameter / 2,
+                self.affine(self.elements[element_num].focus_position),
+                m_integration,
+                False,
+                self.use_spiral_disc_points)
+
+        elif self.elements[element_num].type == 'rect':
+            # compute points using make_cart_rect
+            integration_points = make_cart_rect(
+                self.affine(self.elements[element_num].position),
+                self.elements[element_num].length,
+                self.elements[element_num].width,
+                self.elements[element_num].orientation,
+                m_integration)
+
+        elif self.elements[element_num].type == 'line':
+            # get distance between points in each dimension
+            d = (self.elements[element_num].end_point - self.elements[element_num].start_point) / m_integration
+
+            # compute a set of uniformly spaced Cartesian points
+            # covering the line using linspace, where the end
+            # points are offset by half the point spacing
+            if self.dim == 1:
+                integration_points = np.linspace(self.elements[element_num].start_point + d[0] / 2,
+                                                 self.elements[element_num].end_point - d[0] / 2, m_integration)
+            elif self.dim == 2:
+                px = np.linspace(self.elements[element_num].start_point[0] + d[0] / 2,
+                                 self.elements[element_num].end_point[0] - d[0] / 2, m_integration)
+                py = np.linspace(self.elements[element_num].start_point[1] + d[1] / 2,
+                                 self.elements[element_num].end_point[1] - d[1] / 2, m_integration)
+                integration_points = np.array([px, py])
+            elif self.dim == 3:
+                px = np.linspace(self.elements[element_num].start_point[0] + d[0] / 2,
+                                 self.elements[element_num].end_point[0] - d[0] / 2, m_integration)
+                py = np.linspace(self.elements[element_num].start_point[1] + d[1] / 2,
+                                 self.elements[element_num].end_point[1] - d[1] / 2, m_integration)
+                pz = np.linspace(self.elements[element_num].start_point[2] + d[2] / 2,
+                                 self.elements[element_num].end_point[2] - d[2] / 2, m_integration)
+                integration_points = np.array([px, py, pz])
+
+        else:
+            raise ValueError(f'{self.elements[element_num].type} is not a valid array element type.')
+
+        # recompute actual number of points
+        m_integration = integration_points.shape[1]
+
+        # compute scaling factor
+        scale = m_grid / m_integration
+
+        if self.axisymmetric:
+            # create new expanded grid
+            kgrid_expanded = kWaveGrid(kgrid.Nx, kgrid.dx, 2 * kgrid.Ny, kgrid.dy)
+
+            # remove integration points which are outside grid
+            integration_points = trim_cart_points(kgrid_expanded, integration_points)
+
+            # calculate grid weights from BLIs centered on the integration points
+            grid_weights = off_grid_points(kgrid_expanded, integration_points, scale,
+                                           bli_tolerance=self.bli_tolerance,
+                                           bli_type=self.bli_type,
+                                           mask_only=mask_only,
+                                           single_precision=self.single_precision)
+
+            # keep points in the positive y domain
+            grid_weights = grid_weights[:, kgrid.Ny + 1:]
+
+        else:
+            # remove integration points which are outside grid
+            integration_points = trim_cart_points(kgrid, integration_points)
+
+            # calculate grid weights from BLIs centered on the integration points
+            grid_weights = off_grid_points(kgrid, integration_points, scale,
+                                           bli_tolerance=self.bli_tolerance,
+                                           bli_type=self.bli_type,
+                                           mask_only=mask_only,
+                                           single_precision=self.single_precision)
+
+        return grid_weights
+
+
+def off_grid_points(kgrid, points,
+                    scale=1,
+                    bli_tolerance=0.1,
+                    bli_type='sinc',
+                    mask_only=False,
+                    single_precision=False,
+                    debug=False,
+                    display_wait_bar=False):
+
+    wait_bar_update_freq = 100
+
+    # check dimensions of points input
+    if points.shape[0] != kgrid.dim:
+        raise ValueError("Input points must be given as matrix with dimensions num_dims x num_points.")
+
+    # get the number of off-grid points
+    num_points = points.shape[1]
+
+    # expand scale value if scalar
+    if np.isscalar(scale):
+        scale = scale * np.ones(num_points)
+    elif np.size(scale) != num_points:
+        raise ValueError("Input scale must be scalar or the same length as points.")
+    if not isinstance(debug, bool):
+        raise ValueError("Optional input 'Debug' must be Boolean.")
+
+    if not (isinstance(bli_tolerance, (int, float)) and 0 < bli_tolerance < 1):
+        raise ValueError("bli_tolerance should be a real scalar value between 0 and 1.")
+    if bli_type not in ['sinc', 'exact']:
+        raise ValueError("Optional input 'bli_type' must be either 'sinc' or 'exact'.")
+    if not isinstance(mask_only, bool):
+        raise ValueError("Optional input 'mask_only' must be Boolean.")
+    if not isinstance(single_precision, bool):
+        raise ValueError("Optional input 'single_precision' must be Boolean.")
+    if not isinstance(display_wait_bar, bool):
+        raise ValueError("Optional input 'display_wait_bar' must be Boolean.")
+
+    # reassign bli_tolerance if bli_type is 'exact'
+    if bli_type == 'exact':
+        bli_tolerance = 0
+
+    # extract grid vectors (to avoid recomputing them below)
+    x_vec = kgrid.x_vec
+    y_vec = kgrid.y_vec
+    z_vec = kgrid.z_vec
+
+    # preallocate some variables for speed
+    if bli_tolerance == 0:
+        pi_on_dx = np.pi / kgrid.dx
+        pi_on_dy = np.pi / kgrid.dy
+        pi_on_dz = np.pi / kgrid.dz
+    else:
+        scalar_dxyz = True
+        pi_on_dxyz = np.pi / kgrid.dx
+        if kgrid.dim == 2:
+            if kgrid.dx != kgrid.dy:
+                scalar_dxyz = False
+                pi_on_dxyz = np.pi / np.array([kgrid.dx, kgrid.dy])
+        elif kgrid.dim == 3:
+            if not (kgrid.dx == kgrid.dy and kgrid.dx == kgrid.dz):
+                scalar_dxyz = False
+                pi_on_dxyz = np.pi / np.array([kgrid.dx, kgrid.dy, kgrid.dz])
+
+    # initialise the source mask
+    if mask_only:
+        mask_type = np.bool
+    elif single_precision:
+        mask_type = np.float32
+    else:
+        mask_type = np.float64
+
+    if kgrid.dim == 1:
+        mask = np.zeros((kgrid.Nx, 1), dtype=mask_type)
+    elif kgrid.dim == 2:
+        mask = np.zeros((kgrid.Nx, kgrid.Ny), dtype=mask_type)
+    elif kgrid.dim == 3:
+        mask = np.zeros((kgrid.Nx, kgrid.Ny, kgrid.Nz), dtype=mask_type)
+
+    # display wait bar
+    if display_wait_bar:
+        import tqdm
+        tqdm.tqdm(total=100, desc="Computing off-grid source mask...")
+
+    # add to the overall mask using contributions from each source point
+    import scipy
+    from scipy import signal
+
+    for point_ind in range(num_points):
+        # extract a single point
+        point = points[:, point_ind]
+
+        # convert to the computational coordinate if the physical coordinate is
+        # sampled nonuniformly
+        if kgrid.nonuniform:
+            point, BLIscale = mapPoint(kgrid, point)
+
+        if bli_tolerance == 0:
+            if mask_only:
+                mask = np.ones(mask.shape, dtype=bool)
+                return mask
+            else:
+                if kgrid.dim == 1:
+                    if bli_type == 'sinc':
+                        mask = mask + scale[point_ind] * sinc(pi_on_dx * (x_vec - point[0]))
+                    elif bli_type == 'exact':
+                        mask = mask + scale[point_ind] * get_delta_bli(kgrid.Nx, kgrid.dx, x_vec, point[0])
+
+                elif kgrid.dim == 2:
+                    if bli_type == 'sinc':
+                        mask_t_x = sinc(pi_on_dx * (x_vec - point[0]))
+                        mask_t_y = sinc(pi_on_dy * (y_vec - point[1]))
+                    elif bli_type == 'exact':
+                        mask_t_x = get_delta_bli(kgrid.Nx, kgrid.dx, x_vec, point[0])
+                        mask_t_y = get_delta_bli(kgrid.Ny, kgrid.dy, y_vec, point[1])
+
+                    mask = mask + scale[point_ind] * (mask_t_x @ mask_t_y.T)
+
+                elif kgrid.dim == 3:
+                    if bli_type == 'sinc':
+                        mask_t_x = sinc(pi_on_dx * (x_vec - point[0]))
+                        mask_t_y = sinc(pi_on_dy * (y_vec - point[1]))
+                        mask_t_z = sinc(pi_on_dz * (z_vec - point[2]))
+                    elif bli_type == 'exact':
+                        mask_t_x = get_delta_bli(kgrid.Nx, kgrid.dx, x_vec, point[0])
+                        mask_t_y = get_delta_bli(kgrid.Ny, kgrid.dy, y_vec, point[1])
+                        mask_t_z = get_delta_bli(kgrid.Nz, kgrid.dz, z_vec, point[2])
+
+                    mask = mask + scale[point_ind] * np.reshape(np.kron(mask_t_y @ mask_t_z.T, mask_t_x),
+                                                                [kgrid.Nx, kgrid.Ny, kgrid.Nz])
+
+        else:
+            # create an array of neighbouring grid points for BLI evaluation
+            if kgrid.dim == 1:
+                ind, is_ = tol_star(bli_tolerance, kgrid, point, debug)
+                xs = x_vec[is_]
+                xyz = xs
+            elif kgrid.dim == 2:
+                ind, is_, js = tol_star(bli_tolerance, kgrid, point, debug)
+                xs = x_vec[is_]
+                ys = y_vec[js]
+                xyz = [xs, ys]
+            elif kgrid.dim == 3:
+                ind, is_, js, ks = tol_star(bli_tolerance, kgrid, point, debug)
+                xs = x_vec[is_.astype(int)]
+                ys = y_vec[js.astype(int)]
+                zs = z_vec[ks.astype(int)]
+                xyz = [xs, ys, zs]
+
+            if mask_only:
+                # add current points to the mask
+                mask[ind] = True
+            else:
+                # evaluate a BLI centered on point at grid nodes XYZ
+                if scalar_dxyz:
+                    if single_precision:
+                        mask_t = sinc(np.pi * pi_on_dxyz * (xyz - point.T))
+                    else:
+                        mask_t = sinc(np.pi * pi_on_dxyz * (xyz - point.T))
+                else:
+                    if single_precision:
+                        mask_t = sinc(np.pi * pi_on_dxyz * (xyz - point.T))
+                    else:
+                        mask_t = sinc(np.pi * pi_on_dxyz * (xyz - point.T))
+                mask_t = np.prod(mask_t, axis=1)
+
+                # apply scaling for non-uniform grid
+                if kgrid.nonuniform:
+                    mask_t = mask_t * BLIscale
+
+                # add this contribution to the overall source mask
+                ind = ind.astype(int)
+                # matlab_assign(matlab_mask(mask, ind), matlab_mask(mask, ind) + scale[point_ind] * mask_t)
+                mask[ind] = mask[ind] + scale[point_ind] * mask_t
+
+        # update the waitbar
+        if display_wait_bar and (point_ind % wait_bar_update_freq == 0):
+            tqdm.update(wait_bar_update_freq)
+

--- a/kwave/utils/mapgen.py
+++ b/kwave/utils/mapgen.py
@@ -2541,10 +2541,10 @@ def trim_cart_points(kgrid, points: np.ndarray):
     # find indices for points within the simulation domain
     ind_x = (points[0, :] >= kgrid.x_vec[0]) & (points[0, :] <= kgrid.x_vec[-1])
 
-    if kgrid['dim'] > 1:
+    if kgrid.dim > 1:
         ind_y = (points[1, :] >= kgrid.y_vec[0]) & (points[1, :] <= kgrid.y_vec[-1])
 
-    if kgrid['dim'] > 2:
+    if kgrid.dim > 2:
         ind_z = (points[2, :] >= kgrid.z_vec[0]) & (points[2, :] <= kgrid.z_vec[-1])
 
     # combine indices

--- a/tests/matlab_test_data_collectors/matlab_collectors/collect_kWaveArray.m
+++ b/tests/matlab_test_data_collectors/matlab_collectors/collect_kWaveArray.m
@@ -115,7 +115,7 @@ recorder.recordVariable('mask', mask);
 recorder.increment();
 
 % Useful for testing getDistributedSourceSignal
-% source_signal = rand(12, 20);
+source_signal = rand(12, 20);
 distributed_source_signal = kwave_array.getDistributedSourceSignal(kgrid, source_signal);
 recorder.recordVariable('source_signal', source_signal);
 recorder.recordVariable('distributed_source_signal', distributed_source_signal);
@@ -123,7 +123,7 @@ recorder.increment();
 
 % Useful for testing combineSensorData
 kgrid = kWaveGrid(10, 0.1, 100, 0.1, 100, 0.1);
-% sensor_data = rand(1823, 20);
+sensor_data = rand(1823, 20);
 combined_sensor_data = kwave_array.combineSensorData(kgrid, sensor_data);
 recorder.recordVariable('sensor_data', sensor_data);
 recorder.recordVariable('combined_sensor_data', combined_sensor_data);
@@ -139,7 +139,7 @@ recorder.recordObject('kwave_array', kwave_array);
 recorder.increment();
 
 % Useful for testing setAffineTransform
-% affine_transform = rand(4, 4);
+affine_transform = rand(4, 4);
 kwave_array.setAffineTransform(affine_transform);
 recorder.recordVariable('affine_transform', affine_transform);
 recorder.recordObject('kwave_array', kwave_array);

--- a/tests/matlab_test_data_collectors/matlab_collectors/collect_kWaveArray.m
+++ b/tests/matlab_test_data_collectors/matlab_collectors/collect_kWaveArray.m
@@ -115,7 +115,7 @@ recorder.recordVariable('mask', mask);
 recorder.increment();
 
 % Useful for testing getDistributedSourceSignal
-source_signal = rand(12, 20);
+% source_signal = rand(12, 20);
 distributed_source_signal = kwave_array.getDistributedSourceSignal(kgrid, source_signal);
 recorder.recordVariable('source_signal', source_signal);
 recorder.recordVariable('distributed_source_signal', distributed_source_signal);
@@ -123,7 +123,7 @@ recorder.increment();
 
 % Useful for testing combineSensorData
 kgrid = kWaveGrid(10, 0.1, 100, 0.1, 100, 0.1);
-sensor_data = rand(1823, 20);
+% sensor_data = rand(1823, 20);
 combined_sensor_data = kwave_array.combineSensorData(kgrid, sensor_data);
 recorder.recordVariable('sensor_data', sensor_data);
 recorder.recordVariable('combined_sensor_data', combined_sensor_data);
@@ -139,7 +139,7 @@ recorder.recordObject('kwave_array', kwave_array);
 recorder.increment();
 
 % Useful for testing setAffineTransform
-affine_transform = rand(4, 4);
+% affine_transform = rand(4, 4);
 kwave_array.setAffineTransform(affine_transform);
 recorder.recordVariable('affine_transform', affine_transform);
 recorder.recordObject('kwave_array', kwave_array);

--- a/tests/matlab_test_data_collectors/matlab_collectors/collect_kWaveArray.m
+++ b/tests/matlab_test_data_collectors/matlab_collectors/collect_kWaveArray.m
@@ -38,8 +38,13 @@ kwave_array.addBowlElement([0, 0, 0], 5, 4.3, [1, 5, -3]);
 recorder.recordObject('kwave_array', kwave_array);
 recorder.increment();
 
-% Useful for testing addRectElement in 2D
+% Useful for testing addRectElement in 3D
 kwave_array.addRectElement([12, -8, 0.3], 3, 4, [2, 4, 5]);
+recorder.recordObject('kwave_array', kwave_array);
+recorder.increment();
+
+% Useful for testing addDiscElement in 3D
+kwave_array.addDiscElement([0, 0.3, 12], 5, [1, 5, 8]);
 recorder.recordObject('kwave_array', kwave_array);
 recorder.increment();
 
@@ -51,8 +56,8 @@ kwave_array.addArcElement([0, 0.3], 5, 4.3, [1, 5]);
 recorder.recordObject('kwave_array', kwave_array);
 recorder.increment();
 
-% Useful for testing addDiscElement
-kwave_array.addDiscElement([0, 0.3], 5, [1, 5]);
+% Useful for testing addDiscElement in 2D
+kwave_array.addDiscElement([0, 0.3], 5);
 recorder.recordObject('kwave_array', kwave_array);
 recorder.increment();
 

--- a/tests/matlab_test_data_collectors/python_testers/kWaveArray_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/kWaveArray_test.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import numpy as np
 from kwave.kgrid import kWaveGrid
@@ -9,8 +10,7 @@ from tests.matlab_test_data_collectors.python_testers.utils.record_reader import
 
 
 def test_kwave_array():
-    # test_record_path = os.path.join(Path(__file__).parent, 'collectedValues/kWaveArray.mat')
-    test_record_path = os.path.join('/Users/farid/PycharmProjects/k-wave-python/tests/matlab_test_data_collectors/matlab_collectors', 'collectedValues/kWaveArray.mat')
+    test_record_path = os.path.join(Path(__file__).parent, 'collectedValues/kWaveArray.mat')
     reader = TestRecordReader(test_record_path)
 
     kwave_array = kWaveArray()
@@ -95,57 +95,41 @@ def test_kwave_array():
     grid_weights = kwave_array.get_element_grid_weights(kgrid, 0)
     assert np.allclose(grid_weights, reader.expected_value_of('grid_weights'))
 
+    mask = kwave_array.get_element_binary_mask(kgrid, 0)
+    assert np.allclose(mask, reader.expected_value_of('mask'))
+    reader.increment()
 
-    #
-    # # Useful for testing getElementBinaryMask
-    # mask = kwave_array.getElementBinaryMask(kgrid, 1);
-    # recorder.recordVariable('mask', mask);
-    # recorder.increment();
-    #
-    # # Useful for testing getArrayGridWeights
-    # grid_weights = kwave_array.getArrayGridWeights(kgrid);
-    # recorder.recordVariable('grid_weights', grid_weights);
-    #
-    # # Useful for testing getArrayBinaryMask+
+    grid_weights = kwave_array.get_array_grid_weights(kgrid)
+    assert np.allclose(grid_weights, reader.expected_value_of('grid_weights'))
 
-    # mask = kwave_array.getArrayBinaryMask(kgrid);
-    # recorder.recordVariable('mask', mask);
-    # recorder.increment();
-    #
-    # # Useful for testing getDistributedSourceSignal
-    # source_signal = rand(12, 20);
-    # distributed_source_signal = kwave_array.getDistributedSourceSignal(kgrid, source_signal);
-    # recorder.recordVariable('source_signal', source_signal);
-    # recorder.recordVariable('distributed_source_signal', distributed_source_signal);
-    # recorder.increment();
-    #
-    # # Useful for testing combineSensorData
-    # kgrid = kWaveGrid(10, 0.1, 100, 0.1, 100, 0.1);
-    # sensor_data = rand(1823, 20);
-    # combined_sensor_data = kwave_array.combineSensorData(kgrid, sensor_data);
-    # recorder.recordVariable('sensor_data', sensor_data);
-    # recorder.recordVariable('combined_sensor_data', combined_sensor_data);
-    # recorder.increment();
-    #
-    # # Useful for testing setArrayPosition
-    # translation = [5, 2, -1];
-    # rotation = [20, 30, 15];
-    # kwave_array.setArrayPosition(translation, rotation);
-    # recorder.recordVariable('translation', translation);
-    # recorder.recordVariable('rotation', rotation);
-    # recorder.recordObject('kwave_array', kwave_array);
-    # recorder.increment();
-    #
-    # # Useful for testing setAffineTransform
-    # affine_transform = rand(4, 4);
-    # kwave_array.setAffineTransform(affine_transform);
-    # recorder.recordVariable('affine_transform', affine_transform);
-    # recorder.recordObject('kwave_array', kwave_array);
-    # recorder.increment();
-    #
-    # # Useful for testing addAnnularArray
-    # kwave_array = kWaveArray();
-    # kwave_array.addAnnularArray([3, 5, 10], 5, [1.2; 0.5], [12, 21, 3]);
-    # element_pos = kwave_array.getElementPositions();
-    # recorder.recordVariable('element_pos', element_pos);
-    # recorder.increment();
+    mask = kwave_array.get_array_binary_mask(kgrid)
+    assert np.allclose(mask, reader.expected_value_of('mask'))
+    reader.increment()
+
+    source_signal = reader.expected_value_of('source_signal')
+    distributed_source_signal = kwave_array.get_distributed_source_signal(kgrid, source_signal)
+    assert np.allclose(distributed_source_signal, reader.expected_value_of('distributed_source_signal'))
+    reader.increment()
+
+    kgrid = kWaveGrid([10, 100, 100], [0.1, 0.1, 0.1])
+    sensor_data = reader.expected_value_of('sensor_data')
+    combined_sensor_data = kwave_array.combine_sensor_data(kgrid, sensor_data)
+    assert np.allclose(combined_sensor_data, reader.expected_value_of('combined_sensor_data'))
+    reader.increment()
+
+    translation = reader.expected_value_of('translation')
+    rotation = reader.expected_value_of('rotation')
+    kwave_array.set_array_position(translation, rotation)
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    affine_transform = reader.expected_value_of('affine_transform')
+    kwave_array.set_affine_transform(affine_transform)
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array = kWaveArray()
+    kwave_array.add_annular_array([3, 5, 10], 5, [[1.2, 0.5]], [12, 21, 3])
+    element_pos = kwave_array.get_element_positions()
+    assert np.allclose(element_pos.squeeze(axis=-1), reader.expected_value_of('element_pos'))
+    reader.increment()

--- a/tests/matlab_test_data_collectors/python_testers/kWaveArray_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/kWaveArray_test.py
@@ -93,14 +93,9 @@ def test_kwave_array():
 
     kgrid = kWaveGrid([100, 200, 150], [0.1, 0.3, 0.4])
     grid_weights = kwave_array.get_element_grid_weights(kgrid, 0)
-    print(grid_weights.shape)
+    assert np.allclose(grid_weights, reader.expected_value_of('grid_weights'))
 
 
-
-    # # Useful for testing getElementGridWeights
-    # kgrid = kWaveGrid(100, 0.1, 200, 0.3, 150, 0.4);
-    # grid_weights = kwave_array.getElementGridWeights(kgrid, 1);
-    # recorder.recordVariable('grid_weights', grid_weights);
     #
     # # Useful for testing getElementBinaryMask
     # mask = kwave_array.getElementBinaryMask(kgrid, 1);

--- a/tests/matlab_test_data_collectors/python_testers/kWaveArray_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/kWaveArray_test.py
@@ -1,0 +1,156 @@
+import os
+
+import numpy as np
+from kwave.kgrid import kWaveGrid
+
+from kwave.utils.kwave_array import kWaveArray
+from tests.matlab_test_data_collectors.python_testers.utils.check_equality import check_kwave_array_equality
+from tests.matlab_test_data_collectors.python_testers.utils.record_reader import TestRecordReader
+
+
+def test_kwave_array():
+    # test_record_path = os.path.join(Path(__file__).parent, 'collectedValues/kWaveArray.mat')
+    test_record_path = os.path.join('/Users/farid/PycharmProjects/k-wave-python/tests/matlab_test_data_collectors/matlab_collectors', 'collectedValues/kWaveArray.mat')
+    reader = TestRecordReader(test_record_path)
+
+    kwave_array = kWaveArray()
+
+    # Useful for checking if the defaults are set correctly
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array = kWaveArray(axisymmetric=True, bli_tolerance=0.5, bli_type='sinc', single_precision=True, upsampling_rate=20)
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array = kWaveArray(axisymmetric=False, bli_tolerance=0.5, bli_type='exact', single_precision=False,
+                             upsampling_rate=1)
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array.add_annular_array([3, 5, 10], 5, [[1.2, 0.5]], [12, 21, 3])
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array.add_annular_array([3, 5, 10], 5, [[1.2, 0.5], [5.3, 1.0]], [12, 21, 3])
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array.add_annular_element([0, 0, 0], 5, [0.001, 0.03], [1, 5, -3])
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array.add_bowl_element([0, 0, 0], 5, 4.3, [1, 5, -3])
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array.add_rect_element([12, -8, 0.3], 3, 4, [2, 4, 5])
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array.add_disc_element([0, 0.3, 12], 5, [1, 5, 8])
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array = kWaveArray()
+    kwave_array.add_arc_element([0, 0.3], 5, 4.3, [1, 5])
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array.add_disc_element([0, 0.3], 5)
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    # Useful for testing addRectElement in 2D
+    kwave_array.add_rect_element([12, -8], 3, 4, 2)
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array.remove_element(2)
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+    kwave_array.remove_element(0)
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+    kwave_array.remove_element(0)
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array = kWaveArray()
+    kwave_array.add_line_element([0], [5])
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array = kWaveArray()
+    kwave_array.add_line_element([0, 3], [5, 2])
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kwave_array = kWaveArray()
+    kwave_array.add_line_element([0, 3, -3], [5, 2, -9])
+    check_kwave_array_equality(kwave_array, reader.expected_value_of('kwave_array'))
+    reader.increment()
+
+    kgrid = kWaveGrid([100, 200, 150], [0.1, 0.3, 0.4])
+    grid_weights = kwave_array.get_element_grid_weights(kgrid, 0)
+    print(grid_weights.shape)
+
+
+
+    # # Useful for testing getElementGridWeights
+    # kgrid = kWaveGrid(100, 0.1, 200, 0.3, 150, 0.4);
+    # grid_weights = kwave_array.getElementGridWeights(kgrid, 1);
+    # recorder.recordVariable('grid_weights', grid_weights);
+    #
+    # # Useful for testing getElementBinaryMask
+    # mask = kwave_array.getElementBinaryMask(kgrid, 1);
+    # recorder.recordVariable('mask', mask);
+    # recorder.increment();
+    #
+    # # Useful for testing getArrayGridWeights
+    # grid_weights = kwave_array.getArrayGridWeights(kgrid);
+    # recorder.recordVariable('grid_weights', grid_weights);
+    #
+    # # Useful for testing getArrayBinaryMask+
+
+    # mask = kwave_array.getArrayBinaryMask(kgrid);
+    # recorder.recordVariable('mask', mask);
+    # recorder.increment();
+    #
+    # # Useful for testing getDistributedSourceSignal
+    # source_signal = rand(12, 20);
+    # distributed_source_signal = kwave_array.getDistributedSourceSignal(kgrid, source_signal);
+    # recorder.recordVariable('source_signal', source_signal);
+    # recorder.recordVariable('distributed_source_signal', distributed_source_signal);
+    # recorder.increment();
+    #
+    # # Useful for testing combineSensorData
+    # kgrid = kWaveGrid(10, 0.1, 100, 0.1, 100, 0.1);
+    # sensor_data = rand(1823, 20);
+    # combined_sensor_data = kwave_array.combineSensorData(kgrid, sensor_data);
+    # recorder.recordVariable('sensor_data', sensor_data);
+    # recorder.recordVariable('combined_sensor_data', combined_sensor_data);
+    # recorder.increment();
+    #
+    # # Useful for testing setArrayPosition
+    # translation = [5, 2, -1];
+    # rotation = [20, 30, 15];
+    # kwave_array.setArrayPosition(translation, rotation);
+    # recorder.recordVariable('translation', translation);
+    # recorder.recordVariable('rotation', rotation);
+    # recorder.recordObject('kwave_array', kwave_array);
+    # recorder.increment();
+    #
+    # # Useful for testing setAffineTransform
+    # affine_transform = rand(4, 4);
+    # kwave_array.setAffineTransform(affine_transform);
+    # recorder.recordVariable('affine_transform', affine_transform);
+    # recorder.recordObject('kwave_array', kwave_array);
+    # recorder.increment();
+    #
+    # # Useful for testing addAnnularArray
+    # kwave_array = kWaveArray();
+    # kwave_array.addAnnularArray([3, 5, 10], 5, [1.2; 0.5], [12, 21, 3]);
+    # element_pos = kwave_array.getElementPositions();
+    # recorder.recordVariable('element_pos', element_pos);
+    # recorder.increment();

--- a/tests/matlab_test_data_collectors/python_testers/utils/check_equality.py
+++ b/tests/matlab_test_data_collectors/python_testers/utils/check_equality.py
@@ -110,7 +110,7 @@ def check_kwave_array_equality(kwave_array_object: kWaveArray, expected_kwave_ar
             elif np.size(actual_value) == np.size(expected_value) == 0:
                 are_equal = True
             else:
-                are_equal = (actual_value == expected_value)
+                are_equal = np.abs(actual_value - expected_value) < 1e-10
 
         if not are_equal:
             print('Following property does not match:')

--- a/tests/matlab_test_data_collectors/python_testers/utils/check_equality.py
+++ b/tests/matlab_test_data_collectors/python_testers/utils/check_equality.py
@@ -110,7 +110,12 @@ def check_kwave_array_equality(kwave_array_object: kWaveArray, expected_kwave_ar
             elif np.size(actual_value) == np.size(expected_value) == 0:
                 are_equal = True
             else:
-                are_equal = np.abs(actual_value - expected_value) < 1e-10
+                # check if both are float (either native or numpy), if so, check if they are close
+                if isinstance(actual_value, float) and isinstance(expected_value, float):
+                    are_equal = np.isclose(actual_value, expected_value)
+                else:
+                    are_equal = (actual_value == expected_value)
+
 
         if not are_equal:
             print('Following property does not match:')


### PR DESCRIPTION
Closes #156 
Closes #130 

Migrates `kWaveArray` class, `get_off_grid_points(...)` functions and related code entities to Python. Also, introduces a new test case for comparing the outputs of the Python implementation against the Matlab implementation. 

Note: some functions used in `kWaveArray` are not available in the Python version of the `kWave` yet. Testing logic was designed to skip the invocation of unavailable functions. We should look into this as future work.

#### Complete List of Changes
* Added `tol_star` and `find_closest` functions under `conversions.py`
* Added `kWaveArray` class and its methods
* Bug fix in `trim_cart_points` function
* Updated `collect_kWaveArray.m` with a new test case 
* Added `kWaveArray_test.py` to ensure outputs of the Python version are equal or very similar to the Matlab version
* Added `kWaveArray` comparator to check if the states of the `kWaveArray` object in Python and Matlab tests are equal