### PR TITLE
Examples/at linear array transducer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ kwave/bin/linux
 examples/__pycache__/
 src/
 *.h5
+*.tar.gz
+*.whl
+*.png
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ This example file steps through the process of:
 This example expects an NVIDIA GPU by default to simulate with k-Wave.
 
 To test the reconstruction on a machine with a GPU,
-set `RUN_SIMULATION` [on line 26 of `bmode_reconstruction_example.py`](https://github.com/waltsims/k-wave-python/blob/master/examples/bmode_reconstruction_example.py#L26)
+set `RUN_SIMULATION` [on line 28 of `bmode_reconstruction_example.py`](https://github.com/waltsims/k-wave-python/blob/master/examples/bmode_reconstruction_example.py#L28)
 to `True`, and the example will run without the pre-computed data.
 
 ## Development

--- a/examples/bmode_reconstruction_example.py
+++ b/examples/bmode_reconstruction_example.py
@@ -20,37 +20,30 @@ from kwave.utils.signals import tone_burst
 if __name__ == '__main__':
     # pathname for the input and output files
     pathname = gettempdir()
+    phantom_data_path = 'phantom_data.mat'
+    PHANTOM_DATA_GDRIVE_ID = '1ZfSdJPe8nufZHz0U9IuwHR4chaOGAWO4'
 
     # simulation settings
     DATA_CAST = 'single'
-    RUN_SIMULATION = False
+    RUN_SIMULATION = True
 
-    # =========================================================================
-    # DEFINE THE K-WAVE GRID
-    # =========================================================================
-    print("Setting up the k-wave grid...")
-
-    # set the size of the perfectly matched layer (PML)
     pml_size_points = Vector([20, 10, 10])  # [grid points]
-
-    # set total number of grid points not including the PML
     grid_size_points = Vector([256, 128, 128]) - 2 * pml_size_points  # [grid points]
-
-    # set desired grid size in the x-direction not including the PML
     grid_size_meters = 40e-3  # [m]
-
-    # calculate the spacing between the grid points
     grid_spacing_meters = grid_size_meters / Vector([grid_size_points.x, grid_size_points.x, grid_size_points.x])
 
-    # create the k-space grid
-    kgrid = kWaveGrid(grid_size_points, grid_spacing_meters)
-
-    # =========================================================================
-    # DEFINE THE MEDIUM PARAMETERS
-    # =========================================================================
-    # define the properties of the propagation medium
     c0 = 1540
     rho0 = 1000
+    source_strength = 1e6  # [Pa]
+    tone_burst_freq = 1.5e6  # [Hz]
+    tone_burst_cycles = 4
+
+    kgrid = kWaveGrid(grid_size_points, grid_spacing_meters)
+    t_end = (grid_size_points.x * grid_spacing_meters.x) * 2.2 / c0  # [s]
+    kgrid.makeTime(c0, t_end=t_end)
+
+    input_signal = tone_burst(1 / kgrid.dt, tone_burst_freq, tone_burst_cycles)
+    input_signal = (source_strength / (c0 * rho0)) * input_signal
 
     medium = kWaveMedium(
         sound_speed=None,  # will be set later
@@ -59,33 +52,6 @@ if __name__ == '__main__':
         BonA=6
     )
 
-    # create the time array
-    t_end = (grid_size_points.x * grid_spacing_meters.x) * 2.2 / c0  # [s]
-    kgrid.makeTime(c0, t_end=t_end)
-
-    # =========================================================================
-    # DEFINE THE INPUT SIGNAL
-    # =========================================================================
-    print("Defining the input signal...")
-
-    # define properties of the input signal
-    source_strength = 1e6  # [Pa]
-    tone_burst_freq = 1.5e6  # [Hz]
-    tone_burst_cycles = 4
-
-    # create the input signal using tone_burst
-    input_signal = tone_burst(1 / kgrid.dt, tone_burst_freq, tone_burst_cycles)
-
-    # scale the source magnitude by the source_strength divided by the
-    # impedance (the source is assigned to the particle velocity)
-    input_signal = (source_strength / (c0 * rho0)) * input_signal
-
-    # =========================================================================
-    # DEFINE THE ULTRASOUND TRANSDUCER
-    # =========================================================================
-    print("Setting up the transducer configuration...")
-
-    # physical properties of the transducer
     transducer = dotdict()
     transducer.number_elements = 32  # total number of transducer elements
     transducer.element_width = 2  # width of each element [grid points/voxels]
@@ -95,10 +61,13 @@ if __name__ == '__main__':
 
     # calculate the width of the transducer in grid points
     transducer_width = transducer.number_elements * transducer.element_width + (
-                transducer.number_elements - 1) * transducer.element_spacing
+            transducer.number_elements - 1) * transducer.element_spacing
 
     # use this to position the transducer in the middle of the computational grid
-    transducer.position = np.round([1, grid_size_points.y / 2 - transducer_width / 2, grid_size_points.z / 2 - transducer.element_length / 2])
+    transducer.position = np.round(
+        [1, grid_size_points.y / 2 - transducer_width / 2, grid_size_points.z / 2 - transducer.element_length / 2])
+
+    transducer = kWaveTransducerSimple(kgrid, **transducer)
 
     # properties used to derive the beamforming delays
     not_transducer = dotdict()
@@ -106,52 +75,29 @@ if __name__ == '__main__':
     not_transducer.focus_distance = 20e-3  # focus distance [m]
     not_transducer.elevation_focus_distance = 19e-3  # focus distance in the elevation plane [m]
     not_transducer.steering_angle = 0  # steering angle [degrees]
-
-    # apodization
     not_transducer.transmit_apodization = 'Hanning'
     not_transducer.receive_apodization = 'Rectangular'
-
-    # define the transducer elements that are currently active
     not_transducer.active_elements = np.ones((transducer.number_elements, 1))
-
-    # append input signal used to drive the transducer
     not_transducer.input_signal = input_signal
 
-    # create the transducer using the defined settings
-    transducer = kWaveTransducerSimple(kgrid, **transducer)
     not_transducer = NotATransducer(transducer, kgrid, **not_transducer)
 
-    # =========================================================================
-    # DEFINE THE MEDIUM PROPERTIES
-    # =========================================================================
-    # define a large image size to move across
     number_scan_lines = 96
 
     print("Fetching phantom data...")
-    phantom_data_path = 'phantom_data.mat'
-    PHANTOM_DATA_GDRIVE_ID = '1ZfSdJPe8nufZHz0U9IuwHR4chaOGAWO4'
     download_from_gdrive_if_does_not_exist(PHANTOM_DATA_GDRIVE_ID, phantom_data_path)
 
     phantom = scipy.io.loadmat(phantom_data_path)
     sound_speed_map = phantom['sound_speed_map']
     density_map = phantom['density_map']
 
-    # =========================================================================
-    # RUN THE SIMULATION
-    # =========================================================================
     print(f"RUN_SIMULATION set to {RUN_SIMULATION}")
-    # run the simulation if set to true, otherwise, load previous results from disk
 
-    # set medium position
+    # preallocate the storage set medium position
+    scan_lines = np.zeros((number_scan_lines, not_transducer.number_active_elements, kgrid.Nt))
     medium_position = 0
 
-    # preallocate the storage
-    simulation_data = []
-
-    # loop through the scan lines
-    for scan_line_index in range(1, number_scan_lines + 1):
-        # for scan_line_index in range(1, 10):
-        # update the command line status
+    for scan_line_index in range(0, number_scan_lines):
 
         # load the current section of the medium
         medium.sound_speed = sound_speed_map[:, medium_position:medium_position + grid_size_points.y, :]
@@ -181,11 +127,13 @@ if __name__ == '__main__':
                 execution_options=SimulationExecutionOptions()
             )
 
+            scan_lines[scan_line_index, :] = not_transducer.combine_sensor_data(sensor_data['p'].T)
+
         # update medium position
         medium_position = medium_position + transducer.element_width
 
     if RUN_SIMULATION:
-        simulation_data = np.stack(simulation_data, axis=0)
+        simulation_data = scan_lines
         # scipy.io.savemat('sensor_data.mat', {'sensor_data_all_lines': simulation_data})
 
     else:

--- a/examples/bmode_reconstruction_example.py
+++ b/examples/bmode_reconstruction_example.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
 
     # simulation settings
     DATA_CAST = 'single'
-    RUN_SIMULATION = True
+    RUN_SIMULATION = False
 
     # =========================================================================
     # DEFINE THE K-WAVE GRID

--- a/examples/bmode_reconstruction_example.py
+++ b/examples/bmode_reconstruction_example.py
@@ -8,7 +8,7 @@ from example_utils import download_from_gdrive_if_does_not_exist
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
-from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
+from kwave.kspaceFirstOrder3D import kspaceFirstOrder3D
 from kwave.ktransducer import NotATransducer, kWaveTransducerSimple
 from kwave.options.simulation_execution_options import SimulationExecutionOptions
 from kwave.options.simulation_options import SimulationOptions
@@ -120,7 +120,7 @@ if __name__ == '__main__':
         )
         # run the simulation
         if RUN_SIMULATION:
-            sensor_data = kspaceFirstOrder3DC(
+            sensor_data = kspaceFirstOrder3D(
                 medium=medium,
                 kgrid=kgrid,
                 source=not_transducer,

--- a/examples/bmode_reconstruction_example.py
+++ b/examples/bmode_reconstruction_example.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     # simulation settings
     DATA_CAST = 'single'
-    RUN_SIMULATION = True
+    RUN_SIMULATION = False
 
     pml_size_points = Vector([20, 10, 10])  # [grid points]
     grid_size_points = Vector([256, 128, 128]) - 2 * pml_size_points  # [grid points]

--- a/examples/bmode_reconstruction_example.py
+++ b/examples/bmode_reconstruction_example.py
@@ -4,14 +4,14 @@ from tempfile import gettempdir
 import numpy as np
 import scipy.io
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 from example_utils import download_from_gdrive_if_does_not_exist
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
 from kwave.ktransducer import NotATransducer, kWaveTransducerSimple
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.reconstruction.beamform import beamform
 from kwave.reconstruction.converter import build_channel_data
 from kwave.utils.dotdictionary import dotdict
@@ -23,7 +23,7 @@ if __name__ == '__main__':
 
     # simulation settings
     DATA_CAST = 'single'
-    RUN_SIMULATION = False
+    RUN_SIMULATION = True
 
     # =========================================================================
     # DEFINE THE K-WAVE GRID

--- a/examples/bmode_reconstruction_example.py
+++ b/examples/bmode_reconstruction_example.py
@@ -65,7 +65,8 @@ if __name__ == '__main__':
 
     # use this to position the transducer in the middle of the computational grid
     transducer.position = np.round(
-        [1, grid_size_points.y / 2 - transducer_width / 2, grid_size_points.z / 2 - transducer.element_length / 2])
+        [1, grid_size_points.y / 2 - transducer_width / 2,
+         grid_size_points.z / 2 - transducer.element_length / 2])
 
     transducer = kWaveTransducerSimple(kgrid, **transducer)
 
@@ -100,7 +101,8 @@ if __name__ == '__main__':
     for scan_line_index in range(0, number_scan_lines):
 
         # load the current section of the medium
-        medium.sound_speed = sound_speed_map[:, medium_position:medium_position + grid_size_points.y, :]
+        medium.sound_speed = \
+            sound_speed_map[:, medium_position:medium_position + grid_size_points.y, :]
         medium.density = density_map[:, medium_position:medium_position + grid_size_points.y, :]
 
         # set the input settings
@@ -124,7 +126,7 @@ if __name__ == '__main__':
                 source=not_transducer,
                 sensor=not_transducer,
                 simulation_options=simulation_options,
-                execution_options=SimulationExecutionOptions()
+                execution_options=SimulationExecutionOptions(is_gpu_simulation=True)
             )
 
             scan_lines[scan_line_index, :] = not_transducer.combine_sensor_data(sensor_data['p'].T)

--- a/examples/example_at_linear_array_transducer.py
+++ b/examples/example_at_linear_array_transducer.py
@@ -1,0 +1,97 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+import kwave.data
+from kwave import kWaveGrid, SimulationOptions, kWaveMedium
+from kwave.ksensor import kSensor
+from kwave.ksource import kSource
+from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.utils.kwave_array import kWaveArray
+from kwave.utils.plot import voxel_plot
+from kwave.utils.signals import tone_burst
+
+# DEFINE LITERALS
+model = 1
+c0 = 1500
+rho0 = 1000
+source_f0 = 1e6
+source_amp = 1e6
+source_cycles = 5
+source_focus = 20e-3
+element_num = 15
+element_width = 1e-3
+element_length = 10e-3
+element_pitch = 2e-3
+translation = kwave.data.Vector([5e-3, 0, 8e-3])
+rotation = kwave.data.Vector([0, 20, 0])
+grid_size_x = 40e-3
+grid_size_y = 20e-3
+grid_size_z = 40e-3
+ppw = 3
+t_end = 35e-6
+cfl = 0.5
+
+# GRID
+dx = c0 / (ppw * source_f0)
+Nx = round(grid_size_x / dx)
+Ny = round(grid_size_y / dx)
+Nz = round(grid_size_z / dx)
+kgrid = kWaveGrid([Nx, Ny, Nz], [dx, dx, dx])
+kgrid.makeTime(c0, cfl, t_end)
+
+# SOURCE
+if element_num % 2 != 0:
+    ids = np.arange(1, element_num + 1) - np.ceil(element_num / 2)
+else:
+    ids = np.arange(1, element_num + 1) - (element_num + 1) / 2
+
+time_delays = -(np.sqrt((ids * element_pitch) ** 2 + source_focus ** 2) - source_focus) / c0
+time_delays = time_delays - min(time_delays)
+
+source_sig = source_amp * tone_burst(1 / kgrid.dt, source_f0, source_cycles,
+                                     signal_offset=np.round(time_delays / kgrid.dt).astype(int))
+karray = kWaveArray(bli_tolerance=0.05, upsampling_rate=10)
+
+for ind in range(1, element_num + 1):
+    x_pos = 0 - (element_num * element_pitch / 2 - element_pitch / 2) + (ind - 1) * element_pitch
+    karray.add_rect_element([x_pos, 0, kgrid.z_vec[0]], element_width, element_length, rotation)
+
+karray.set_array_position(translation, rotation)
+source = kSource()
+source.p_mask = karray.get_array_binary_mask(kgrid)
+voxel_plot(np.single(source.p_mask))
+source.p = karray.get_distributed_source_signal(kgrid, source_sig)
+# MEDIUM
+
+medium = kWaveMedium(sound_speed=c0, density=rho0)
+
+# SENSOR
+sensor_mask = np.zeros((Nx, Ny, Nz))
+sensor_mask[:, Ny // 2, :] = 1
+sensor = kSensor(sensor_mask, record=['p_max'])
+
+# SIMULATION
+simulation_options = SimulationOptions(
+    pml_auto=True,
+    pml_inside=False,
+    save_to_disk=True,
+    data_cast='single',
+)
+
+execution_options = SimulationExecutionOptions()
+
+sensor_data = kspaceFirstOrder3DC(kgrid=kgrid, medium=medium, source=source, sensor=sensor,
+                                  simulation_options=simulation_options, execution_options=execution_options)
+
+p_max = np.reshape(sensor_data['p_max'], (Nx, Nz), order='F')
+
+# VISUALISATION
+plt.figure()
+plt.imshow(1e-6 * p_max, extent=[1e3 * kgrid.x_vec[0][0], 1e3 * kgrid.x_vec[-1][0], 1e3 * kgrid.z_vec[0][0],
+                                 1e3 * kgrid.z_vec[-1][0]], aspect='auto')
+plt.xlabel('z-position [mm]')
+plt.ylabel('x-position [mm]')
+plt.title('Pressure Field')
+plt.colorbar(label='[MPa]')
+plt.show()

--- a/examples/example_at_linear_array_transducer.py
+++ b/examples/example_at_linear_array_transducer.py
@@ -79,7 +79,7 @@ simulation_options = SimulationOptions(
     data_cast='single',
 )
 
-execution_options = SimulationExecutionOptions()
+execution_options = SimulationExecutionOptions(is_gpu_simulation=True)
 
 sensor_data = kspaceFirstOrder3DC(kgrid=kgrid, medium=medium, source=source, sensor=sensor,
                                   simulation_options=simulation_options, execution_options=execution_options)

--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -6,14 +6,18 @@ import unittest.mock
 from pathlib import Path
 
 import h5py
-import numpy as np
+
+from kwave.options.simulation_options import SimulationType
+from kwave.utils.dotdictionary import dotdict
 
 
 class Executor:
 
-    def __init__(self, device):
+    def __init__(self, device, execution_options, simulation_options):
 
         binary_name = 'kspaceFirstOrder'
+        self.execution_options = execution_options
+        self.simulation_options = simulation_options
         if device == 'gpu':
             binary_name += '-CUDA'
         elif device == 'cpu':
@@ -30,8 +34,8 @@ class Executor:
         elif self._is_windows:
             binary_folder = 'windows'
             binary_name += '.exe'
-        elif self._is_darwin:
-            raise NotImplementedError('k-wave-python is currently unsupported on MacOS.')
+        # elif self._is_darwin:
+        #     raise NotImplementedError('k-wave-python is currently unsupported on MacOS.')
 
         path_of_this_file = Path(__file__).parent.resolve()
         self.binary_path = path_of_this_file / 'bin' / binary_folder / binary_name
@@ -59,7 +63,65 @@ class Executor:
             if isinstance(return_code, unittest.mock.MagicMock):
                 logging.info('Skipping AssertionError in testing.')
 
-        with h5py.File(output_filename, 'r') as hf:
-            sensor_data = np.array(hf['p'])[0].T
+        sensor_data = self.parse_executable_output(output_filename)
 
+        return sensor_data
+
+    def parse_executable_output(self, output_filename: str) -> dotdict:
+
+        # Load the simulation and pml sizes from the output file
+        with h5py.File(output_filename, 'r') as output_file:
+            Nx, Ny, Nz = output_file['/Nx'][0].item(), output_file['/Ny'][0].item(), output_file['/Nz'][0].item()
+            pml_x_size, pml_y_size = output_file['/pml_x_size'][0].item(), output_file['/pml_y_size'][0].item()
+            pml_z_size = output_file['/pml_z_size'][0].item() if Nz > 1 else 0
+
+        # Set the default index variables for the _all and _final variables
+        x1, x2 = 1, Nx
+        y1, y2 = (
+            1, 1 + pml_y_size) if self.simulation_options.simulation_type is not SimulationType.AXISYMMETRIC else (
+            1, Ny)
+        z1, z2 = (1 + pml_z_size, Nz - pml_z_size) if Nz > 1 else (1, Nz)
+
+        # Check if the PML is set to be outside the computational grid
+        if self.simulation_options.pml_inside:
+            x1, x2 = 1 + pml_x_size, Nx - pml_x_size
+            y1, y2 = (1, Ny) if self.simulation_options.simulation_type is SimulationType.AXISYMMETRIC else (
+                1 + pml_y_size, Ny - pml_y_size)
+            z1, z2 = 1 + pml_z_size, Nz - pml_z_size if Nz > 1 else (1, Nz)
+
+        # Load the C++ data back from disk using h5py
+        with h5py.File(output_filename, 'r') as output_file:
+            sensor_data = {}
+            for key in output_file.keys():
+                sensor_data[key] = output_file[f'/{key}'][0].squeeze()
+        #     if self.simulation_options.cuboid_corners:
+        #         sensor_data = [output_file[f'/p/{index}'][()] for index in range(1, len(key['mask']) + 1)]
+        #
+        # # Combine the sensor data if using a kWaveTransducer as a sensor
+        # if isinstance(sensor, kWaveTransducer):
+        #     sensor_data['p'] = sensor.combine_sensor_data(sensor_data['p'])
+
+        # # Compute the intensity outputs
+        # if any(key.startswith(('I_avg', 'I')) for key in sensor.get('record', [])):
+        #     flags = {
+        #         'record_I_avg': 'I_avg' in sensor['record'],
+        #         'record_I': 'I' in sensor['record'],
+        #         'record_p': 'p' in sensor['record'],
+        #         'record_u_non_staggered': 'u_non_staggered' in sensor['record']
+        #     }
+        #     kspaceFirstOrder_saveIntensity()
+        #
+        # # Filter the recorded time domain pressure signals using a Gaussian filter if defined
+        # if not time_rev and 'frequency_response' in sensor:
+        #     frequency_response = sensor['frequency_response']
+        #     sensor_data['p'] = gaussianFilter(sensor_data['p'], 1 / kgrid.dt, frequency_response[0], frequency_response[1])
+        #
+        # # Assign sensor_data.p to sensor_data if sensor.record is not given
+        # if 'record' not in sensor and not cuboid_corners:
+        #     sensor_data = sensor_data['p']
+        #
+        # # Delete the input and output files
+        # if delete_data:
+        #     os.remove(input_filename)
+        #     os.remove(output_filename)
         return sensor_data

--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -5,7 +5,6 @@ import unittest.mock
 
 import h5py
 
-from kwave.options.simulation_options import SimulationType
 from kwave.utils.dotdictionary import dotdict
 
 
@@ -23,7 +22,11 @@ class Executor:
 
     def run_simulation(self, input_filename: str, output_filename: str, options: str):
 
-        command = f'{self.execution_options.system_string} {self.execution_options.binary_path} -i {input_filename} -o {output_filename} {options}'
+        command = f'{self.execution_options.system_string} ' \
+                  f'{self.execution_options.binary_path} ' \
+                  f'-i {input_filename} ' \
+                  f'-o {output_filename} ' \
+                  f'{options}'
         return_code = os.system(command)
 
         try:
@@ -39,24 +42,24 @@ class Executor:
     def parse_executable_output(self, output_filename: str) -> dotdict:
 
         # Load the simulation and pml sizes from the output file
-        with h5py.File(output_filename, 'r') as output_file:
-            Nx, Ny, Nz = output_file['/Nx'][0].item(), output_file['/Ny'][0].item(), output_file['/Nz'][0].item()
-            pml_x_size, pml_y_size = output_file['/pml_x_size'][0].item(), output_file['/pml_y_size'][0].item()
-            pml_z_size = output_file['/pml_z_size'][0].item() if Nz > 1 else 0
+        # with h5py.File(output_filename, 'r') as output_file:
+        #     Nx, Ny, Nz = output_file['/Nx'][0].item(), output_file['/Ny'][0].item(), output_file['/Nz'][0].item()
+        #     pml_x_size, pml_y_size = output_file['/pml_x_size'][0].item(), output_file['/pml_y_size'][0].item()
+        #     pml_z_size = output_file['/pml_z_size'][0].item() if Nz > 1 else 0
 
-        # Set the default index variables for the _all and _final variables
-        x1, x2 = 1, Nx
-        y1, y2 = (
-            1, 1 + pml_y_size) if self.simulation_options.simulation_type is not SimulationType.AXISYMMETRIC else (
-            1, Ny)
-        z1, z2 = (1 + pml_z_size, Nz - pml_z_size) if Nz > 1 else (1, Nz)
-
-        # Check if the PML is set to be outside the computational grid
-        if self.simulation_options.pml_inside:
-            x1, x2 = 1 + pml_x_size, Nx - pml_x_size
-            y1, y2 = (1, Ny) if self.simulation_options.simulation_type is SimulationType.AXISYMMETRIC else (
-                1 + pml_y_size, Ny - pml_y_size)
-            z1, z2 = 1 + pml_z_size, Nz - pml_z_size if Nz > 1 else (1, Nz)
+        # # Set the default index variables for the _all and _final variables
+        # x1, x2 = 1, Nx
+        # y1, y2 = (
+        #     1, 1 + pml_y_size) if self.simulation_options.simulation_type is not SimulationType.AXISYMMETRIC else (
+        #     1, Ny)
+        # z1, z2 = (1 + pml_z_size, Nz - pml_z_size) if Nz > 1 else (1, Nz)
+        #
+        # # Check if the PML is set to be outside the computational grid
+        # if self.simulation_options.pml_inside:
+        #     x1, x2 = 1 + pml_x_size, Nx - pml_x_size
+        #     y1, y2 = (1, Ny) if self.simulation_options.simulation_type is SimulationType.AXISYMMETRIC else (
+        #         1 + pml_y_size, Ny - pml_y_size)
+        #     z1, z2 = 1 + pml_z_size, Nz - pml_z_size if Nz > 1 else (1, Nz)
 
         # Load the C++ data back from disk using h5py
         with h5py.File(output_filename, 'r') as output_file:

--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -34,8 +34,8 @@ class Executor:
         elif self._is_windows:
             binary_folder = 'windows'
             binary_name += '.exe'
-        # elif self._is_darwin:
-        #     raise NotImplementedError('k-wave-python is currently unsupported on MacOS.')
+        elif self._is_darwin:
+            raise NotImplementedError('k-wave-python is currently unsupported on MacOS.')
 
         path_of_this_file = Path(__file__).parent.resolve()
         self.binary_path = path_of_this_file / 'bin' / binary_folder / binary_name

--- a/kwave/kWaveSimulation_helper/display_simulation_params.py
+++ b/kwave/kWaveSimulation_helper/display_simulation_params.py
@@ -11,7 +11,7 @@ def display_simulation_params(kgrid: kWaveGrid, medium: kWaveMedium, elastic_cod
     k_size = kgrid.size
 
     # display time step information
-    print('  dt: ', f'{scale_SI(dt)[0]}s', f', t_end: {scale_SI(t_array_end)[0]}s', ', time steps:', Nt)
+    print('  dt: ', f'{scale_SI(dt)[0]}s, t_end: {scale_SI(t_array_end)[0]}s, time steps:', Nt)
 
     c_min, c_min_comp, c_min_shear = get_min_sound_speed(medium, elastic_code)
 

--- a/kwave/kgrid.py
+++ b/kwave/kgrid.py
@@ -483,7 +483,7 @@ class kWaveGrid(object):
         self.dt = cfl * min_grid_dim / c_max
 
         # assign number of time steps based on t_end
-        self.Nt = np.floor(t_end / self.dt) + 1
+        self.Nt = int(np.floor(t_end / self.dt) + 1)
 
         # catch case where dt is a recurring number
         if (np.floor(t_end / self.dt) != np.ceil(t_end / self.dt)) and (matlab.rem(t_end, self.dt) == 0):

--- a/kwave/kgrid.py
+++ b/kwave/kgrid.py
@@ -486,7 +486,9 @@ class kWaveGrid(object):
         self.Nt = int(np.floor(t_end / self.dt) + 1)
 
         # catch case where dt is a recurring number
-        if (np.floor(t_end / self.dt) != np.ceil(t_end / self.dt)) and (matlab.rem(t_end, self.dt) == 0):
+        # TODO: this line is more correct but breaks linear transducer comparison test. Compare with kWave Matlab
+        # if (np.floor(t_end / self.dt) != np.ceil(t_end / self.dt)) and (matlab.rem(t_end, self.dt) == 0):
+        if (int(t_end / self.dt) != math.ceil(t_end / self.dt)) and (t_end % self.dt == 0):
             self.Nt = self.Nt + 1
 
         return self.t_array, self.dt

--- a/kwave/kgrid.py
+++ b/kwave/kgrid.py
@@ -486,9 +486,7 @@ class kWaveGrid(object):
         self.Nt = int(np.floor(t_end / self.dt) + 1)
 
         # catch case where dt is a recurring number
-        # TODO: this line is more correct but breaks linear transducer comparison test. Compare with kWave Matlab
-        # if (np.floor(t_end / self.dt) != np.ceil(t_end / self.dt)) and (matlab.rem(t_end, self.dt) == 0):
-        if (int(t_end / self.dt) != math.ceil(t_end / self.dt)) and (t_end % self.dt == 0):
+        if (np.floor(t_end / self.dt) != np.ceil(t_end / self.dt)) and (matlab.rem(t_end, self.dt) == 0):
             self.Nt = self.Nt + 1
 
         return self.t_array, self.dt

--- a/kwave/kspaceFirstOrder2D.py
+++ b/kwave/kspaceFirstOrder2D.py
@@ -1,7 +1,6 @@
 from typing import Union
 
 import numpy as np
-from numpy.fft import ifftshift
 
 from kwave.executor import Executor
 from kwave.kWaveSimulation import kWaveSimulation
@@ -283,7 +282,6 @@ def kspaceFirstOrder2D(
         medium: kWaveMedium instance
         source: kWaveSource instance
         sensor: kWaveSensor instance
-        **kwargs:
 
     Returns:
 

--- a/kwave/kspaceFirstOrder2D.py
+++ b/kwave/kspaceFirstOrder2D.py
@@ -3,21 +3,18 @@ import tempfile
 from typing import Union
 
 import numpy as np
-
-from kwave.kmedium import kWaveMedium
-from kwave.ksensor import kSensor
-
-from kwave.ktransducer import NotATransducer
-
-from kwave.kgrid import kWaveGrid
 from numpy.fft import ifftshift
 
 from kwave.executor import Executor
 from kwave.kWaveSimulation import kWaveSimulation
 from kwave.kWaveSimulation_helper import retract_transducer_grid_size, save_to_disk_func
+from kwave.kgrid import kWaveGrid
+from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
-from kwave.options.simulation_options import SimulationOptions
+from kwave.ktransducer import NotATransducer
 from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.interp import interpolate2d
 from kwave.utils.pml import get_pml
@@ -441,7 +438,7 @@ def kspaceFirstOrder2D(
         input_filename = k_sim.options.save_to_disk
         output_filename = os.path.join(tempfile.gettempdir(), 'output.h5')
 
-        executor = Executor(device='gpu')
         executor_options = execution_options.get_options_string(sensor=k_sim.sensor)
-        sensor_data = executor.run_simulation(input_filename, output_filename, options=executor_options)
+        executor = Executor(simulation_options, execution_options)
+        sensor_data = executor.run_simulation(input_filename, output_filename)
         return k_sim.sensor.combine_sensor_data(sensor_data)

--- a/kwave/kspaceFirstOrder2D.py
+++ b/kwave/kspaceFirstOrder2D.py
@@ -1,5 +1,3 @@
-import os
-import tempfile
 from typing import Union
 
 import numpy as np
@@ -436,10 +434,8 @@ def kspaceFirstOrder2D(
         if options.save_to_disk_exit:
             return
 
-        input_filename = k_sim.options.save_to_disk
-        output_filename = os.path.join(tempfile.gettempdir(), 'output.h5')
-
+        executor = Executor(simulation_options=simulation_options, execution_options=execution_options)
         executor_options = execution_options.get_options_string(sensor=k_sim.sensor)
-        executor = Executor(simulation_options, execution_options)
-        sensor_data = executor.run_simulation(input_filename, output_filename)
+        sensor_data = executor.run_simulation(k_sim.options.input_filename, k_sim.options.output_filename,
+                                              options=executor_options)
         return sensor_data

--- a/kwave/kspaceFirstOrder2D.py
+++ b/kwave/kspaceFirstOrder2D.py
@@ -57,7 +57,7 @@ def kspace_first_order_2d_gpu(
     of kspaceFirstOrder3DC by replacing the binary name with the name of the
     GPU binary.
     """
-    assert execution_options.is_gpu_simulation, 'kspaceFirstOrder2DG can only be used for GPU simulations'
+    execution_options.is_gpu_simulation = True  # force to GPU
     sensor_data = kspaceFirstOrder2DC(
         kgrid=kgrid,
         source=source,
@@ -124,6 +124,7 @@ def kspaceFirstOrder2DC(
     Returns:
         Sensor data as a numpy array
     """
+    execution_options.is_gpu_simulation = False  # force to CPU
     # generate the input file and save to disk
     sensor_data = kspaceFirstOrder2D(
         kgrid=kgrid,

--- a/kwave/kspaceFirstOrder2D.py
+++ b/kwave/kspaceFirstOrder2D.py
@@ -441,4 +441,4 @@ def kspaceFirstOrder2D(
         executor_options = execution_options.get_options_string(sensor=k_sim.sensor)
         executor = Executor(simulation_options, execution_options)
         sensor_data = executor.run_simulation(input_filename, output_filename)
-        return k_sim.sensor.combine_sensor_data(sensor_data)
+        return sensor_data

--- a/kwave/kspaceFirstOrder3D.py
+++ b/kwave/kspaceFirstOrder3D.py
@@ -458,8 +458,8 @@ def kspaceFirstOrder3D(
         if options.save_to_disk_exit:
             return
 
-        executor = Executor(device='gpu')
+        executor = Executor(device='gpu', simulation_options=simulation_options, execution_options=execution_options)
         executor_options = execution_options.get_options_string(sensor=k_sim.sensor)
         sensor_data = executor.run_simulation(k_sim.options.input_filename, k_sim.options.output_filename,
                                               options=executor_options)
-        return k_sim.sensor.combine_sensor_data(sensor_data)
+        return sensor_data

--- a/kwave/kspaceFirstOrder3D.py
+++ b/kwave/kspaceFirstOrder3D.py
@@ -458,7 +458,7 @@ def kspaceFirstOrder3D(
         if options.save_to_disk_exit:
             return
 
-        executor = Executor(device='gpu', simulation_options=simulation_options, execution_options=execution_options)
+        executor = Executor(simulation_options=simulation_options, execution_options=execution_options)
         executor_options = execution_options.get_options_string(sensor=k_sim.sensor)
         sensor_data = executor.run_simulation(k_sim.options.input_filename, k_sim.options.output_filename,
                                               options=executor_options)

--- a/kwave/kspaceFirstOrder3D.py
+++ b/kwave/kspaceFirstOrder3D.py
@@ -62,8 +62,9 @@ def kspaceFirstOrder3DG(
     Returns:
 
     """
+    execution_options.is_gpu_simulation = True
     assert execution_options.is_gpu_simulation, 'kspaceFirstOrder2DG can only be used for GPU simulations'
-    sensor_data = kspaceFirstOrder3DC(
+    sensor_data = kspaceFirstOrder3D(
         kgrid=kgrid,
         source=source,
         sensor=sensor,
@@ -119,6 +120,7 @@ def kspaceFirstOrder3DC(
     Returns:
 
     """
+    execution_options.is_gpu_simulation = False
     # generate the input file and save to disk
     sensor_data = kspaceFirstOrder3D(
         kgrid=kgrid,

--- a/kwave/kspaceFirstOrderAS.py
+++ b/kwave/kspaceFirstOrderAS.py
@@ -1,13 +1,6 @@
-import os
-import tempfile
 from typing import Union
 
 import numpy as np
-
-from kwave.kmedium import kWaveMedium
-from kwave.ksensor import kSensor
-
-from kwave.ktransducer import NotATransducer
 from numpy.fft import ifftshift
 
 from kwave import kWaveGrid
@@ -15,9 +8,12 @@ from kwave.enums import DiscreteCosine
 from kwave.executor import Executor
 from kwave.kWaveSimulation import kWaveSimulation
 from kwave.kWaveSimulation_helper import retract_transducer_grid_size, save_to_disk_func
+from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
 from kwave.ksource import kSource
-from kwave.options.simulation_options import SimulationOptions, SimulationType
+from kwave.ktransducer import NotATransducer
 from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions, SimulationType
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.interp import interpolate2d
 from kwave.utils.math import sinc
@@ -365,10 +361,8 @@ def kspaceFirstOrderAS(
         if options.save_to_disk_exit:
             return
 
-        input_filename = k_sim.options.save_to_disk
-        output_filename = os.path.join(tempfile.gettempdir(), 'output.h5')
-
-        executor = Executor(device='gpu')
+        executor = Executor(simulation_options=simulation_options, execution_options=execution_options)
         executor_options = execution_options.get_options_string(sensor=k_sim.sensor)
-        sensor_data = executor.run_simulation(input_filename, output_filename, options=executor_options)
-        return k_sim.sensor.combine_sensor_data(sensor_data)
+        sensor_data = executor.run_simulation(k_sim.options.input_filename, k_sim.options.output_filename,
+                                              options=executor_options)
+        return sensor_data

--- a/kwave/ktransducer.py
+++ b/kwave/ktransducer.py
@@ -466,7 +466,7 @@ class NotATransducer(kSensor):
 
     @property
     def number_active_elements(self):
-        return self.active_elements.sum()
+        return int(self.active_elements.sum())
 
     @property
     def appended_zeros(self):

--- a/kwave/options/__init__.py
+++ b/kwave/options/__init__.py
@@ -1,2 +1,0 @@
-from kwave.options.simulation_options import SimulationOptions
-from kwave.options.simulation_execution_options import SimulationExecutionOptions

--- a/kwave/options/simulation_execution_options.py
+++ b/kwave/options/simulation_execution_options.py
@@ -1,8 +1,6 @@
 import os
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Optional, Union
-from warnings import warn
 
 from kwave.ksensor import kSensor
 from kwave.utils.checks import is_unix
@@ -51,6 +49,7 @@ class SimulationExecutionOptions:
             assert self.num_threads > 0 and self.num_threads != float('inf')
         else:
             assert self.num_threads == 'all'
+            self.num_threads = None
 
         assert isinstance(self.verbose_level, int) and 0 <= self.verbose_level <= 2
 

--- a/kwave/options/simulation_execution_options.py
+++ b/kwave/options/simulation_execution_options.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional, Union
 
 from kwave.ksensor import kSensor

--- a/kwave/options/simulation_options.py
+++ b/kwave/options/simulation_options.py
@@ -82,7 +82,7 @@ class SimulationOptions(object):
     pml_inside: bool = True
     pml_alpha: float = 2.0
     save_to_disk: bool = False
-    save_to_disk_exit: bool = True
+    save_to_disk_exit: bool = False
     scale_source_terms: bool = True
     smooth_c0: bool = False
     smooth_rho0: bool = False

--- a/kwave/options/simulation_options.py
+++ b/kwave/options/simulation_options.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import numbers
+
 import os
 from dataclasses import dataclass, field
 from enum import Enum
@@ -292,7 +292,10 @@ class SimulationOptions(object):
                 "Optional input ''use_fd'' only supported in 1D."
         # get optimal pml size
         if options.simulation_type.is_axisymmetric() or options.pml_auto:
-            pml_size_temp = get_optimal_pml_size(kgrid, options.pml_search_range, options.radial_symmetry[:4])
+            if options.simulation_type.is_axisymmetric():
+                pml_size_temp = get_optimal_pml_size(kgrid, options.pml_search_range, options.radial_symmetry[:4])
+            else:
+                pml_size_temp = get_optimal_pml_size(kgrid, options.pml_search_range)
 
             # assign to individual variables
             if kgrid.dim == 1:

--- a/kwave/utils/angular_spectrum.py
+++ b/kwave/utils/angular_spectrum.py
@@ -127,7 +127,6 @@ def angular_spectrum(
             absorbing = True
 
     else:
-
         # assign the sound speed
         c0 = medium
 

--- a/kwave/utils/kwave_array.py
+++ b/kwave/utils/kwave_array.py
@@ -570,13 +570,13 @@ class kWaveArray(object):
             data_type = 'float64'
             sz_bytes = num_source_points * Nt * 8
 
-        sz_ind = 0
+        sz_ind = 1
         while sz_bytes > 1024:
             sz_bytes = sz_bytes / 1024
             sz_ind += 1
 
         prefixes = ['', 'K', 'M', 'G', 'T']
-        sz_bytes = round(sz_bytes, 2)
+        sz_bytes = np.round(sz_bytes, 2)  # TODO: should round to significant to map matlab functionality
         print(f'approximate size of source matrix: {str(sz_bytes)} {prefixes[sz_ind]} B ( {data_type} precision)')
 
         source_signal = source_signal.astype(data_type)

--- a/kwave/utils/kwave_array.py
+++ b/kwave/utils/kwave_array.py
@@ -11,7 +11,8 @@ import kwave
 from kwave.kgrid import kWaveGrid
 from kwave.utils.conversion import tol_star
 from kwave.utils.interp import get_delta_bli
-from kwave.utils.mapgen import trim_cart_points, make_cart_rect, make_cart_arc
+from kwave.utils.mapgen import trim_cart_points, make_cart_rect, make_cart_arc, make_cart_bowl, make_cart_disc, \
+    make_cart_spherical_segment
 from kwave.utils.math import sinc, get_affine_matrix
 from kwave.utils.matlab import matlab_assign, matlab_mask, matlab_find
 

--- a/kwave/utils/kwave_array.py
+++ b/kwave/utils/kwave_array.py
@@ -1,13 +1,14 @@
 import time
 from dataclasses import dataclass
+from math import ceil
 from typing import Optional
 
 import numpy as np
-from kwave.kgrid import kWaveGrid
 from numpy import arcsin, pi, cos, size, array
 from numpy.linalg import linalg
-from math import ceil
 
+import kwave
+from kwave.kgrid import kWaveGrid
 from kwave.utils.conversion import tol_star
 from kwave.utils.interp import get_delta_bli
 from kwave.utils.mapgen import trim_cart_points, make_cart_rect, make_cart_arc
@@ -231,7 +232,8 @@ class kWaveArray(object):
                 "Input position for rectangular element must be specified as a 2 (2D) or 3 (3D) element array.")
 
         if coord_dim == 3:
-            assert isinstance(theta, (list, tuple)) and len(theta) == 3, "'theta' must be a list or tuple of length 3"
+            assert isinstance(theta, (kwave.data.Vector, list, tuple)) and len(
+                theta) == 3, "'theta' must be a list or tuple of length 3"
         else:
             assert isinstance(theta, (int, float)), "'theta' must be an integer or float"
 
@@ -412,7 +414,7 @@ class kWaveArray(object):
         # apply transformation
         vec = np.append(vec, [1])
         vec = np.matmul(self.array_transformation, vec)
-        return vec
+        return vec[:-1]
 
     def get_off_grid_points(self, kgrid, element_num, mask_only):
 

--- a/kwave/utils/matlab.py
+++ b/kwave/utils/matlab.py
@@ -3,6 +3,35 @@ from typing import Tuple, Union, Optional, List
 import numpy as np
 
 
+def rem(x, y, rtol=1e-05, atol=1e-08):
+    """
+    Returns the remainder after division of x by y, taking into account the floating point precision.
+    x and y must be real and have compatible sizes.
+    This function is equivalent to the MATLAB rem function.
+
+    Args:
+        x (float, list, or ndarray): The dividend(s).
+        y (float, list, or ndarray): The divisor(s).
+        rtol (float): The relative tolerance parameter (see numpy.isclose).
+        atol (float): The absolute tolerance parameter (see numpy.isclose).
+
+    Returns:
+        float or ndarray: The remainder after division.
+    """
+    if np.any(y == 0):
+        return np.nan
+
+    quotient = x / y
+    closest_int = np.round(quotient)
+
+    # check if quotient is close to an integer value
+    if np.isclose(quotient, closest_int, rtol=rtol, atol=atol).all():
+        return np.zeros_like(x)
+
+    remainder = x - np.fix(quotient) * y
+
+    return remainder
+
 def matlab_assign(matrix: np.ndarray, indices: Union[int, np.ndarray],
                   values: Union[int, float, np.ndarray]) -> np.ndarray:
     """

--- a/kwave/utils/matlab.py
+++ b/kwave/utils/matlab.py
@@ -7,7 +7,7 @@ def rem(x, y, rtol=1e-05, atol=1e-08):
     """
     Returns the remainder after division of x by y, taking into account the floating point precision.
     x and y must be real and have compatible sizes.
-    This function is equivalent to the MATLAB rem function.
+    This function should be equivalent to the MATLAB rem function.
 
     Args:
         x (float, list, or ndarray): The dividend(s).

--- a/kwave/utils/plot.py
+++ b/kwave/utils/plot.py
@@ -1,0 +1,43 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def voxel_plot(mat, axis_tight=False, color=(1, 1, 0.4), transparency=0.8):
+    """
+    Generates a 3D voxel plot of a binary matrix.
+
+    Args:
+        mat (numpy.ndarray): Input 3D matrix in single or double precision.
+        axis_tight (bool): Whether axis limits are set to only display the filled voxels (default = False).
+        color (tuple): Three-element tuple specifying RGB color (default = (1, 1, 0.4)).
+        transparency (float): Value between 0 and 1 specifying transparency where 1 gives no transparency (default = 0.8).
+
+    Returns:
+        None
+    """
+    # Check input matrix is 3D and single or double precision
+    if len(mat.shape) != 3 or not np.issubdtype(mat.dtype, np.floating):
+        raise ValueError('Input must be a 3D matrix in single or double precision.')
+
+    # Normalize the matrix
+    mat = mat / np.max(mat)
+
+    # Create 3D figure
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    ax.voxels(mat, facecolors=color, alpha=transparency, edgecolors=(0.5, 0.5, 0.5, 0.5))
+
+    # Set the axes properties and labels
+    ax.view_init(elev=35, azim=-35)  # Adjust viewing angles here
+    ax.set_xlabel('x [voxels]')
+    ax.set_ylabel('y [voxels]')
+    ax.set_zlabel('z [voxels]')
+
+    if not axis_tight:
+        sz = mat.shape
+        ax.set_xlim([0.5, sz[2] + 0.5])
+        ax.set_ylim([0.5, sz[1] + 0.5])
+        ax.set_zlim([0.5, sz[0] + 0.5])
+
+    # Show the plot
+    plt.show()

--- a/kwave/utils/signals.py
+++ b/kwave/utils/signals.py
@@ -332,7 +332,7 @@ def tone_burst(sample_freq, signal_freq, num_cycles, envelope='Gaussian', plot_s
         created tone burst
 
     """
-    assert isinstance(signal_offset, int), "signal_offset must be integer"
+    # assert isinstance(signal_offset, int), "signal_offset must be integer"
     assert isinstance(signal_length, int), "signal_length must be integer"
 
     # calculate the temporal spacing
@@ -347,7 +347,7 @@ def tone_burst(sample_freq, signal_freq, num_cycles, envelope='Gaussian', plot_s
         tone_t = np.arange(0, tone_length, dt)
 
     tone_burst = np.sin(2 * np.pi * signal_freq * tone_t)
-    tone_index = round(signal_offset)
+    tone_index = np.round(signal_offset)
 
     # check for ring up and ring down input
     if isinstance(envelope, list) or isinstance(envelope, np.ndarray):  # and envelope.size == 2:
@@ -403,7 +403,6 @@ def tone_burst(sample_freq, signal_freq, num_cycles, envelope='Gaussian', plot_s
     # fw = 2 * sqrt(2 * log(2) * w_var)
 
     # Convert tone_index and signal_offset to numpy arrays
-    tone_index = np.array([tone_index])
     signal_offset = np.array(signal_offset)
 
     # Determine the length of the signal array
@@ -413,7 +412,11 @@ def tone_burst(sample_freq, signal_freq, num_cycles, envelope='Gaussian', plot_s
     signal = np.zeros((tone_index.size, signal_length))
 
     # Add the tone burst to the signal array
-    signal[:, tone_index[0]:tone_index[0] + len(tone_burst)] = tone_burst.T
+    if isinstance(tone_index, np.int64):
+        tone_index = [tone_index]
+
+    for offset_index in tone_index:
+        signal[:, offset_index:offset_index + len(tone_burst)] = tone_burst.T
 
     # plot the signal if required
     if plot_signal:

--- a/kwave/utils/signals.py
+++ b/kwave/utils/signals.py
@@ -412,12 +412,14 @@ def tone_burst(sample_freq, signal_freq, num_cycles, envelope='Gaussian', plot_s
     signal = np.zeros((tone_index.size, signal_length))
 
     # Add the tone burst to the signal array
-    if isinstance(tone_index, np.int64):
-        tone_index = [tone_index]
+    # Add the tone burst to the signal array
+    tone_index = np.atleast_1d(tone_index)
 
-    for offset, tone_idx in enumerate(tone_index):
-        signal[offset, tone_idx:tone_idx + len(tone_burst)] = tone_burst.T
-
+    if tone_index.size == 1:
+        signal[:, int(tone_index):int(tone_index) + len(tone_burst)] = tone_burst.T
+    else:
+        for offset, tone_idx in enumerate(tone_index):
+            signal[offset, int(tone_idx):int(tone_idx) + len(tone_burst)] = tone_burst.T
     # plot the signal if required
     if plot_signal:
         raise NotImplementedError

--- a/kwave/utils/signals.py
+++ b/kwave/utils/signals.py
@@ -332,7 +332,8 @@ def tone_burst(sample_freq, signal_freq, num_cycles, envelope='Gaussian', plot_s
         created tone burst
 
     """
-    # assert isinstance(signal_offset, int), "signal_offset must be integer"
+    assert isinstance(signal_offset, int) or isinstance(signal_offset,
+                                                        np.ndarray), "signal_offset must be integer or array of integers"
     assert isinstance(signal_length, int), "signal_length must be integer"
 
     # calculate the temporal spacing

--- a/kwave/utils/signals.py
+++ b/kwave/utils/signals.py
@@ -415,8 +415,8 @@ def tone_burst(sample_freq, signal_freq, num_cycles, envelope='Gaussian', plot_s
     if isinstance(tone_index, np.int64):
         tone_index = [tone_index]
 
-    for offset_index in tone_index:
-        signal[:, offset_index:offset_index + len(tone_burst)] = tone_burst.T
+    for offset, tone_idx in enumerate(tone_index):
+        signal[offset, tone_idx:tone_idx + len(tone_burst)] = tone_burst.T
 
     # plot the signal if required
     if plot_signal:

--- a/tests/diff_utils.py
+++ b/tests/diff_utils.py
@@ -1,8 +1,5 @@
-import os
 from pprint import pprint
 from warnings import warn
-
-import h5py
 
 from tests.h5_summary import H5Summary
 
@@ -18,18 +15,18 @@ def compare_against_ref(reference: str, h5_path, eps=1e-8, precision=8):
         pprint(diff)
     return len(diff) == 0
 
-
-def check_h5_equality(path_a, path_b):
-    # H5DIFF doesn't support excluding attributes from comparison
-    # Therefore we remove them manually
-    # Don't apply this procedure in the final version!
-    for path in [path_a, path_b]:
-        with h5py.File(path, "a") as f:
-            for attr in ['creation_date', 'file_description', 'created_by']:
-                if attr in f.attrs:
-                    del f.attrs[attr]
-
-    cmd = f'h5diff -c -d 0.00000001 {path_a} {path_b}'
-    print(cmd)
-    res = os.system(cmd)
-    return res == 0
+# Note: this is no longer used, but kept for reference
+# def check_h5_equality(path_a, path_b):
+#     # H5DIFF doesn't support excluding attributes from comparison
+#     # Therefore we remove them manually
+#     # Don't apply this procedure in the final version!
+#     for path in [path_a, path_b]:
+#         with h5py.File(path, "a") as f:
+#             for attr in ['creation_date', 'file_description', 'created_by', 'Nt']:
+#                 if attr in f.attrs:
+#                     del f.attrs[attr]
+#
+#     cmd = f'h5diff -c -d 0.00000001 {path_a} {path_b}'
+#     print(cmd)
+#     res = os.system(cmd)
+#     return res == 0

--- a/tests/h5_summary.py
+++ b/tests/h5_summary.py
@@ -1,11 +1,11 @@
 import json
 import os
 from copy import deepcopy
-
-import numpy as np
-import h5py
-from deepdiff import DeepDiff
 from hashlib import sha256
+
+import h5py
+import numpy as np
+from deepdiff import DeepDiff
 
 
 class H5Summary(object):
@@ -69,7 +69,8 @@ class H5Summary(object):
         excluded = [
             "root['root']['attrs']['created_by']",
             "root['root']['attrs']['creation_date']",
-            "root['root']['attrs']['file_description']"
+            "root['root']['attrs']['file_description']",
+            "root['Nt']"  # Skip Nt after updating kgrid logic
         ]
         own_summary = self._strip_checksums(precision)
         other_summary = other._strip_checksums(precision)

--- a/tests/matlab_test_data_collectors/run_all_collectors.m
+++ b/tests/matlab_test_data_collectors/run_all_collectors.m
@@ -14,6 +14,16 @@ for idx=1:length(files)
         run(fullfile(directory, files{idx}));
 end
 
+updateCollectedValues(directory);
+
+function updateCollectedValues(directory)
+    target = pwd + "/python_testers/collectedValues";
+    if exist(target, 'dir')
+        rmdir(target, 's')
+    end
+    movefile(directory + "/collectedValues", target)
+end
+
 function files = getListOfFiles(directory)
     list    = dir(fullfile(directory, '*.m'));
     files = {list.name};

--- a/tests/matlab_test_data_collectors/run_all_collectors.m
+++ b/tests/matlab_test_data_collectors/run_all_collectors.m
@@ -14,9 +14,16 @@ for idx=1:length(files)
         run(fullfile(directory, files{idx}));
 end
 
-updateCollectedValues(directory);
+if ~isRunningInCI()
+    updatePythonCollectedValues(directory);
+end
 
-function updateCollectedValues(directory)
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function is_running_in_ci = isRunningInCI()
+    is_running_in_ci = ~isempty(getenv('CI'));
+end
+
+function updatePythonCollectedValues(directory)
     target = pwd + "/python_testers/collectedValues";
     if exist(target, 'dir')
         rmdir(target, 's')

--- a/tests/test_cpp_running_simulations.py
+++ b/tests/test_cpp_running_simulations.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 import h5py
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
-from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC, kspaceFirstOrder3DG
+from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.filters import filter_time_series
 from kwave.utils.mapgen import make_ball

--- a/tests/test_ivp_3D_simulation.py
+++ b/tests/test_ivp_3D_simulation.py
@@ -19,7 +19,8 @@ from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
 from kwave.ktransducer import kSensor
-from kwave.options import SimulationExecutionOptions, SimulationOptions
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.mapgen import make_ball
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_ivp_axisymmetric_simulation.py
+++ b/tests/test_ivp_axisymmetric_simulation.py
@@ -11,9 +11,6 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test  # noqa: F401
 from kwave.data import Vector

--- a/tests/test_ivp_axisymmetric_simulation.py
+++ b/tests/test_ivp_axisymmetric_simulation.py
@@ -11,22 +11,21 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrderAS import kspaceFirstOrderASC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.mapgen import make_disc
 from tests.diff_utils import compare_against_ref
 
 
 def test_ivp_axisymmetric_simulation():
-
     # create the computational grid
     grid_size = Vector([128, 64])  # [grid points]
     grid_spacing = 0.1e-3 * Vector([1, 1])  # [m]

--- a/tests/test_ivp_binary_sensor_mask.py
+++ b/tests/test_ivp_binary_sensor_mask.py
@@ -12,17 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
 from kwave.ktransducer import kSensor
 from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.mapgen import make_disc, make_circle
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_ivp_comparison_modelling_functions.py
+++ b/tests/test_ivp_comparison_modelling_functions.py
@@ -10,16 +10,16 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.conversion import cart2grid
 from kwave.utils.mapgen import make_disc, make_cart_circle
 from tests.diff_utils import compare_against_ref

--- a/tests/test_ivp_heterogeneous_medium.py
+++ b/tests/test_ivp_heterogeneous_medium.py
@@ -12,24 +12,24 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.mapgen import make_disc, make_cart_circle
 from tests.diff_utils import compare_against_ref
 
 
 def test_ivp_heterogeneous_medium():
     # create the computational grid
-    grid_size = Vector([128, 128]) # [grid points]
-    grid_spacing = Vector([0.1e-3, 0.1e-3]) # [m]
+    grid_size = Vector([128, 128])  # [grid points]
+    grid_spacing = Vector([0.1e-3, 0.1e-3])  # [m]
     kgrid = kWaveGrid(grid_size, grid_spacing)
 
     # define the properties of the propagation medium
@@ -37,8 +37,8 @@ def test_ivp_heterogeneous_medium():
         sound_speed=1500 * np.ones(grid_size),
         density=1000 * np.ones(grid_size)
     )
-    medium.sound_speed[0:grid_size.x//2, :] = 1800         # [m/s]
-    medium.density[:, grid_size.y//4-1:grid_size.y] = 1200          # [kg/m^3]
+    medium.sound_speed[0:grid_size.x // 2, :] = 1800  # [m/s]
+    medium.density[:, grid_size.y // 4 - 1:grid_size.y] = 1200  # [kg/m^3]
 
     # create initial pressure distribution using make_disc
     disc_magnitude = 5 # [Pa]

--- a/tests/test_ivp_homogeneous_medium.py
+++ b/tests/test_ivp_homogeneous_medium.py
@@ -10,16 +10,16 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.mapgen import make_disc, make_cart_circle
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_ivp_loading_external_image.py
+++ b/tests/test_ivp_loading_external_image.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.io import load_image
 from kwave.utils.mapgen import make_cart_circle
 from tests.diff_utils import compare_against_ref

--- a/tests/test_ivp_opposing_corners_sensor_mask.py
+++ b/tests/test_ivp_opposing_corners_sensor_mask.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
 from kwave.ktransducer import kSensor
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.mapgen import make_disc
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_ivp_photoacoustic_waveforms.py
+++ b/tests/test_ivp_photoacoustic_waveforms.py
@@ -12,17 +12,17 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.mapgen import make_ball, make_disc
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_ivp_sensor_frequency_response.py
+++ b/tests/test_ivp_sensor_frequency_response.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.mapgen import make_disc, make_cart_circle
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_kutils.py
+++ b/tests/test_kutils.py
@@ -136,6 +136,32 @@ def test_get_alpha_filters_1D():
     get_alpha_filter(kgrid, medium, ['max'])
 
 
+def test_make_time():
+    """This test case checks the makeTime function where dt is a recurring number."""
+
+    # set the size of the perfectly matched layer (PML)
+    pml_size = Vector([20, 10, 10])  # [grid points]
+
+    # set total number of grid points not including the PML
+    grid_size_points = Vector([256, 128, 128]) - 2 * pml_size  # [grid points]
+
+    # set desired grid size in the x-direction not including the PML
+    grid_size_meters = 40e-3  # [m]
+
+    # calculate the spacing between the grid points
+    grid_spacing_meters = grid_size_meters / Vector([grid_size_points.x, grid_size_points.x, grid_size_points.x])  # [m]
+
+    # create the k-space grid
+    kgrid = kWaveGrid(grid_size_points, grid_spacing_meters)
+
+    c0 = 1540
+    # create the time array
+    t_end = (grid_size_points.x * grid_spacing_meters.x) * 2.2 / c0  # [s]
+    kgrid.makeTime(c0, t_end=t_end)
+
+    assert kgrid.Nt == 1586, f'Time array length of {kgrid.Nt} is not correct. Expected 1586.'
+
+
 def test_focus():
     # simulation settings
     DATA_CAST = 'single'

--- a/tests/test_na_controlling_the_PML.py
+++ b/tests/test_na_controlling_the_PML.py
@@ -10,16 +10,16 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.mapgen import make_disc, make_cart_circle
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_na_optimising_performance.py
+++ b/tests/test_na_optimising_performance.py
@@ -10,16 +10,16 @@ import os
 from copy import deepcopy
 from tempfile import gettempdir
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
 from kwave.ktransducer import kSensor
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.conversion import cart2grid
 from kwave.utils.io import load_image
 from kwave.utils.mapgen import make_cart_circle

--- a/tests/test_pr_2D_FFT_line_sensor.py
+++ b/tests/test_pr_2D_FFT_line_sensor.py
@@ -11,16 +11,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.filters import smooth
 from kwave.utils.mapgen import make_disc
 from tests.diff_utils import compare_against_ref

--- a/tests/test_pr_2D_TR_circular_sensor.py
+++ b/tests/test_pr_2D_TR_circular_sensor.py
@@ -11,16 +11,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.filters import smooth
 from kwave.utils.io import load_image
 from kwave.utils.mapgen import make_cart_circle

--- a/tests/test_pr_2D_TR_directional_sensors.py
+++ b/tests/test_pr_2D_TR_directional_sensors.py
@@ -12,23 +12,22 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensorDirectivity, kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.filters import smooth
 from kwave.utils.mapgen import make_disc
 from tests.diff_utils import compare_against_ref
 
 
 def test_pr_2D_TR_directional_sensors():
-
     # create the computational grid
     pml_size = Vector([20, 20])  # size of the PML in grid points
     grid_size = Vector([128, 256]) - 2 * pml_size  # [grid points]

--- a/tests/test_pr_2D_TR_line_sensor.py
+++ b/tests/test_pr_2D_TR_line_sensor.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.filters import smooth
 from kwave.utils.mapgen import make_disc
 from tests.diff_utils import compare_against_ref

--- a/tests/test_pr_3D_FFT_planar_sensor.py
+++ b/tests/test_pr_3D_FFT_planar_sensor.py
@@ -11,16 +11,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
 from kwave.ktransducer import kSensor
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.filters import smooth
 from kwave.utils.mapgen import make_ball
 from tests.diff_utils import compare_against_ref

--- a/tests/test_sd_directional_array_elements.py
+++ b/tests/test_sd_directional_array_elements.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.filters import filter_time_series
 from kwave.utils.mapgen import make_circle
 from kwave.utils.matlab import matlab_find, matlab_mask, unflatten_matlab_mask
@@ -30,7 +30,7 @@ from tests.diff_utils import compare_against_ref
 
 def test_sd_directional_array_elements():
     # create the computational grid
-    grid_size = Vector([180, 180]) # [grid points]
+    grid_size = Vector([180, 180])  # [grid points]
     grid_spacing = Vector([0.1e-3, 0.1e-3])  # [m]
     kgrid = kWaveGrid(grid_size, grid_spacing)
 

--- a/tests/test_sd_directivity_modelling_2D.py
+++ b/tests/test_sd_directivity_modelling_2D.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.conversion import cart2grid
 from kwave.utils.filters import filter_time_series
 from kwave.utils.mapgen import make_cart_circle

--- a/tests/test_sd_directivity_modelling_3D.py
+++ b/tests/test_sd_directivity_modelling_3D.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.conversion import cart2grid
 from kwave.utils.filters import filter_time_series
 from kwave.utils.mapgen import make_cart_circle

--- a/tests/test_sd_focussed_detector_2D.py
+++ b/tests/test_sd_focussed_detector_2D.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
 from kwave.ktransducer import kSensor
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.mapgen import make_disc, make_circle
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_sd_sensor_directivity_2D.py
+++ b/tests/test_sd_sensor_directivity_2D.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensorDirectivity, kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from tests.diff_utils import compare_against_ref
 
 

--- a/tests/test_tvsp_3D_simulation.py
+++ b/tests/test_tvsp_3D_simulation.py
@@ -7,21 +7,20 @@
     Simulating Ultrasound Beam Patterns examples.
 """
 import os
-from copy import deepcopy
 from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
 from kwave.ktransducer import kSensor
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.filters import filter_time_series
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_tvsp_doppler_effect.py
+++ b/tests/test_tvsp_doppler_effect.py
@@ -12,9 +12,6 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test  # noqa: F401
 from kwave.data import Vector

--- a/tests/test_tvsp_doppler_effect.py
+++ b/tests/test_tvsp_doppler_effect.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.filters import filter_time_series
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_tvsp_homogeneous_medium_dipole.py
+++ b/tests/test_tvsp_homogeneous_medium_dipole.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
 from kwave.ktransducer import kSensor
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.filters import filter_time_series
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_tvsp_homogeneous_medium_monopole.py
+++ b/tests/test_tvsp_homogeneous_medium_monopole.py
@@ -12,16 +12,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.filters import filter_time_series
 from tests.diff_utils import compare_against_ref
 

--- a/tests/test_us_beam_patterns.py
+++ b/tests/test_us_beam_patterns.py
@@ -11,16 +11,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
 from kwave.ktransducer import kWaveTransducerSimple, NotATransducer
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.signals import tone_burst
 from tests.diff_utils import compare_against_ref
@@ -28,9 +28,9 @@ from tests.diff_utils import compare_against_ref
 
 def test_us_beam_patterns():
     # simulation settings
-    DATA_CAST = 'single'       # set to 'single' or 'gpuArray-single' to speed up computations
-    MASK_PLANE = 'xy'          # set to 'xy' or 'xz' to generate the beam pattern in different planes
-    USE_STATISTICS = True      # set to true to compute the rms or peak beam patterns, set to false to compute the harmonic beam patterns
+    DATA_CAST = 'single'  # set to 'single' or 'gpuArray-single' to speed up computations
+    MASK_PLANE = 'xy'  # set to 'xy' or 'xz' to generate the beam pattern in different planes
+    USE_STATISTICS = True  # set to true to compute the rms or peak beam patterns, set to false to compute the harmonic beam patterns
 
     # =========================================================================
     # DEFINE THE K-WAVE GRID

--- a/tests/test_us_bmode_linear_transducer.py
+++ b/tests/test_us_bmode_linear_transducer.py
@@ -11,15 +11,15 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
 from kwave.ktransducer import kWaveTransducerSimple, NotATransducer
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.mapgen import make_ball
 from kwave.utils.signals import tone_burst

--- a/tests/test_us_bmode_linear_transducer.py
+++ b/tests/test_us_bmode_linear_transducer.py
@@ -37,7 +37,6 @@ def test_us_bmode_linear_transducer():
 
     # simulation settings
     DATA_CAST = 'single'
-    RUN_SIMULATION = True
 
     # =========================================================================
     # DEFINE THE K-WAVE GRID
@@ -196,7 +195,6 @@ def test_us_bmode_linear_transducer():
     sound_speed_map[scattering_region3 == 1] = scattering_c0[scattering_region3 == 1]
     density_map[scattering_region3 == 1] = scattering_rho0[scattering_region3 == 1]
 
-
     # =========================================================================
     # RUN THE SIMULATION
     # =========================================================================
@@ -204,56 +202,52 @@ def test_us_bmode_linear_transducer():
     # preallocate the storage
     scan_lines = np.zeros((number_scan_lines, kgrid.Nt))
 
-    # run the simulation if set to true, otherwise, load previous results from disk
-    if RUN_SIMULATION:
+    # set medium position
+    medium_position = 0
 
-        # set medium position
-        medium_position = 0
+    # loop through the scan lines
+    # for scan_line_index in range(1, number_scan_lines + 1):
+    for scan_line_index in range(1, 10):
+        # update the command line status
+        print(f'Computing scan line {scan_line_index} of {number_scan_lines}')
 
-        # loop through the scan lines
-        # for scan_line_index in range(1, number_scan_lines + 1):
-        for scan_line_index in range(1, 10):
-            # update the command line status
-            print(f'Computing scan line {scan_line_index} of {number_scan_lines}')
+        # load the current section of the medium
+        medium.sound_speed = sound_speed_map[:, medium_position:medium_position + grid_size_points.y, :]
+        medium.density = density_map[:, medium_position:medium_position + grid_size_points.y, :]
 
-            # load the current section of the medium
-            medium.sound_speed = sound_speed_map[:, medium_position:medium_position + grid_size_points.y, :]
-            medium.density = density_map[:, medium_position:medium_position + grid_size_points.y, :]
+        # set the input settings
+        input_filename = f'example_lin_tran_input.h5'
+        pathname = gettempdir()
+        input_file_full_path = os.path.join(pathname, input_filename)
+        simulation_options = SimulationOptions(
+            pml_inside=False,
+            pml_size=pml_size,
+            data_cast=DATA_CAST,
+            data_recast=True,
+            save_to_disk=True,
+            input_filename=input_filename,
+            save_to_disk_exit=True,
+            data_path=pathname
+        )
+        # run the simulation
+        kspaceFirstOrder3DC(
+            medium=medium,
+            kgrid=kgrid,
+            source=not_transducer,
+            sensor=not_transducer,
+            simulation_options=simulation_options,
+            execution_options=SimulationExecutionOptions()
+        )
 
-            # set the input settings
-            input_filename = f'example_lin_tran_input.h5'
-            pathname = gettempdir()
-            input_file_full_path = os.path.join(pathname, input_filename)
-            simulation_options = SimulationOptions(
-                pml_inside=False,
-                pml_size=pml_size,
-                data_cast=DATA_CAST,
-                data_recast=True,
-                save_to_disk=True,
-                input_filename=input_filename,
-                save_to_disk_exit=True,
-                data_path=pathname
-            )
-            # run the simulation
-            kspaceFirstOrder3DC(
-                medium=medium,
-                kgrid=kgrid,
-                source=not_transducer,
-                sensor=not_transducer,
-                simulation_options=simulation_options,
-                execution_options=SimulationExecutionOptions()
-            )
+        assert compare_against_ref(f'out_us_bmode_linear_transducer/input_{scan_line_index}', input_file_full_path,
+                                   precision=6), \
+            'Files do not match!'
 
-            assert compare_against_ref(f'out_us_bmode_linear_transducer/input_{scan_line_index}', input_file_full_path, precision=6), \
-                'Files do not match!'
+        # extract the scan line from the sensor data
+        # scan_lines(scan_line_index, :) = transducer.scan_line(sensor_data);
 
-            # extract the scan line from the sensor data
-            # scan_lines(scan_line_index, :) = transducer.scan_line(sensor_data);
-
-            # update medium position
-            medium_position = medium_position + transducer.element_width
+        # update medium position
+        medium_position = medium_position + transducer.element_width
 
         # % save the scan lines to disk
         # save example_us_bmode_scan_lines scan_lines;
-    else:
-        raise NotImplementedError

--- a/tests/test_us_bmode_phased_array.py
+++ b/tests/test_us_bmode_phased_array.py
@@ -7,20 +7,19 @@
     Simulating Ultrasound Beam Patterns examples.
 """
 import os
-from copy import deepcopy
 from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
 from kwave.ktransducer import kWaveTransducerSimple, NotATransducer
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.mapgen import make_ball
 from kwave.utils.signals import tone_burst

--- a/tests/test_us_defining_transducer.py
+++ b/tests/test_us_defining_transducer.py
@@ -11,16 +11,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
 from kwave.ktransducer import kWaveTransducerSimple, NotATransducer
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.signals import tone_burst
 from tests.diff_utils import compare_against_ref
@@ -28,7 +28,7 @@ from tests.diff_utils import compare_against_ref
 
 def test_us_defining_transducer():
     # input and output filenames (these must have the .h5 extension)
-    input_filename  = 'example_input.h5'
+    input_filename = 'example_input.h5'
     output_filename = 'example_output.h5'
 
     # pathname for the input and output files

--- a/tests/test_us_transducer_as_sensor.py
+++ b/tests/test_us_transducer_as_sensor.py
@@ -11,16 +11,16 @@ from tempfile import gettempdir
 
 import numpy as np
 
-from kwave.data import Vector
-from kwave.options import SimulationOptions, SimulationExecutionOptions
-
 # noinspection PyUnresolvedReferences
 import setup_test
+from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksource import kSource
 from kwave.kspaceFirstOrder3D import kspaceFirstOrder3DC
 from kwave.ktransducer import kWaveTransducerSimple, NotATransducer
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
 from kwave.utils.dotdictionary import dotdict
 from kwave.utils.mapgen import make_ball
 from kwave.utils.signals import tone_burst
@@ -29,7 +29,7 @@ from tests.diff_utils import compare_against_ref
 
 def test_us_transducer_as_sensor():
     # input and output filenames (these must have the .h5 extension)
-    input_filename  = 'example_input.h5'
+    input_filename = 'example_input.h5'
     output_filename = 'example_output.h5'
 
     # pathname for the input and output files


### PR DESCRIPTION
This PR does the following:

* adds the at_linear_array_transducer example to k-wave-python (closes #175)
* fixes and cleans up the bmode_reconstruction example (related to #122)
* fixes minor kgrid bugs
 - add matlab.rem for near-machine-precision modulo operations
 - Fix make time always to have correct length Nt and add test for the failure case
* Adds the functionality to automatically move the Matlab collected values to the proper directory locally
* Adds voxel plot functionality
* Fixes minor bugs in kwave_array
* Updates display formatting in display simulation params to remove unneeded spaces
* update [kwave/options/__init__.py](https://github.com/waltsims/k-wave-python/pull/174/files#diff-f51fb0065265765965167aa9f72d2bfbc2162823bdc335da4fc049b5e3d69810) to remove circular imports
* update `SimulationOptions` default values to be `save_to_disk_exit: bool = False`
* Update executor
        - Update signature to accept `SumulationOptions` and `ExecutionOptions`
        - Executor now returns all values stored in the output.h5 file as `sensor_data` as a dictionary (closes #46)
*    ` number_active_elements(self):` property in kTransducer now returns `int` type
* update execution options to accept 'all' as a valid number of threads
* update `kwave_array.add_rect_element(self, position, Lx, Ly, theta):` to accept vector types. 
* modify check_h5_equality to skip 'Nt' value since reference files are now outdated.
* Remove device logic from Executor in exchange for  simulation_execution_options (closes #176)
* Allow an array of offsets to be passed to toneBurst for beamformed transmit signal generation.
* add imports of add_cart_* to karray (closes #177) 
* ensures the correct execution device for kspaceFirstOrder{2,3}D{C,G} (closes #159)