### PR TITLE
Update workflow checkout to v4

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: k-Wave-python
       - name: checkout reference k-Wave repo

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           path: k-Wave-python
       - name: checkout reference k-Wave repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ucl-bug/k-wave
           path: k-wave
@@ -50,7 +50,7 @@ jobs:
         python-version: [ "3.8", "3.9", "3.10" ]
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download collectedValues
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: [ "3.8", "3.9" ] #, "3.10" ]
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
A [new release](https://github.com/actions/checkout/releases/tag/v4.0.0) of the checkout workflow came out yesterday. At one point in the afternoon yesterday, this was [breaking quite a few CI workflows on Github](https://github.com/actions/checkout/issues/1450). 