### PR TITLE
Test nearest neighbor mode of resize function

### DIFF
--- a/tests/matlab_test_data_collectors/matlab_collectors/collect_resize.m
+++ b/tests/matlab_test_data_collectors/matlab_collectors/collect_resize.m
@@ -3,9 +3,7 @@
 output_file = 'collectedValues/resize.mat';
 recorder = utils.TestRecorder(output_file);
 
-% TODO: test also for nearest
-% interp_methods = {'nearest', 'linear'};
-interp_methods = {'linear'};
+interp_methods = {'nearest', 'linear'};
 
 % Generate a random 3D volume with dimensions Nx x Ny x Nz
 Nx = randi([10,20]);
@@ -30,4 +28,3 @@ for method = interp_methods
 
 end
 recorder.saveRecordsToDisk(); 
-    

--- a/tests/matlab_test_data_collectors/python_testers/test_resize.py
+++ b/tests/matlab_test_data_collectors/python_testers/test_resize.py
@@ -22,5 +22,6 @@ def test_resize():
 
         assert np.allclose(expected_resized_volume,
                            resized_volume), f"Results do not match for {i + 1} dimensional case."
+        reader.increment()
 
-    logging.log(logging.INFO, 'revolve2d(..) works as expected!')
+    logging.log(logging.INFO, 'resize(..) works as expected!')


### PR DESCRIPTION
Closes #97 

Extends the `resize` function's unit test to test against the nearest neighbor interpolation case