### PR TITLE
238 bug attributeerror kwavesimulation object has no attribute record u split field

### DIFF
--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -1,7 +1,6 @@
 import logging
 import stat
 import subprocess
-import traceback
 import unittest.mock
 
 import h5py

--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -1,6 +1,7 @@
 import logging
 import stat
 import subprocess
+import traceback
 import unittest.mock
 
 import h5py
@@ -29,13 +30,13 @@ class Executor:
                   f'{options}'
         
         stdout = None if self.execution_options.show_sim_log else subprocess.DEVNULL
-        return_code = subprocess.run(command, stdout=stdout, shell=True).returncode
-
         try:
-            assert return_code == 0, f'Simulation call returned code: {return_code}'
-        except AssertionError:
-            if isinstance(return_code, unittest.mock.MagicMock):
+            subprocess.run(command, stdout=stdout, shell=True, check=True)
+        except subprocess.CalledProcessError as e:
+            if isinstance(e.returncode, unittest.mock.MagicMock):
                 logging.info('Skipping AssertionError in testing.')
+            else:
+                raise(e)
 
         sensor_data = self.parse_executable_output(output_filename)
 

--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -36,7 +36,7 @@ class Executor:
             if isinstance(e.returncode, unittest.mock.MagicMock):
                 logging.info('Skipping AssertionError in testing.')
             else:
-                raise(e)
+                raise
 
         sensor_data = self.parse_executable_output(output_filename)
 

--- a/kwave/kspaceFirstOrder2D.py
+++ b/kwave/kspaceFirstOrder2D.py
@@ -295,11 +295,12 @@ def kspaceFirstOrder2D(
     # start the timer and store the start time
     TicToc.tic()
 
-    if execution_options.is_gpu_simulation:
-        assert simulation_options.save_to_disk, 'GPU simulation requires saving to disk'
-    else:
-        # Currently we only support binary execution, meaning all simulations must be saved to disk.
-        assert simulation_options.save_to_disk, 'CPU simulation requires saving to disk'
+    # Currently we only support binary execution, meaning all simulations must be saved to disk.
+    if not simulation_options.save_to_disk:
+        if execution_options.is_gpu_simulation:
+            raise ValueError('GPU simulation requires saving to disk. Please set SimulationOptions.save_to_disk=True')
+        else:
+            raise ValueError('CPU simulation requires saving to disk. Please set SimulationOptions.save_to_disk=True')
 
     k_sim = kWaveSimulation(
         kgrid=kgrid,

--- a/kwave/kspaceFirstOrder2D.py
+++ b/kwave/kspaceFirstOrder2D.py
@@ -61,7 +61,7 @@ def kspace_first_order_2d_gpu(
     assert isinstance(execution_options,
                       SimulationExecutionOptions), 'execution_options must be a SimulationExecutionOptions object'
 
-    sensor_data = kspaceFirstOrder2DC(
+    sensor_data = kspaceFirstOrder2D(
         kgrid=kgrid,
         source=source,
         sensor=sensor,

--- a/kwave/kspaceFirstOrder2D.py
+++ b/kwave/kspaceFirstOrder2D.py
@@ -295,6 +295,12 @@ def kspaceFirstOrder2D(
     # start the timer and store the start time
     TicToc.tic()
 
+    if execution_options.is_gpu_simulation:
+        assert simulation_options.save_to_disk, 'GPU simulation requires saving to disk'
+    else:
+        # Currently we only support binary execution, meaning all simulations must be saved to disk.
+        assert simulation_options.save_to_disk, 'CPU simulation requires saving to disk'
+
     k_sim = kWaveSimulation(
         kgrid=kgrid,
         source=source,
@@ -302,6 +308,7 @@ def kspaceFirstOrder2D(
         medium=medium,
         simulation_options=simulation_options
     )
+
     k_sim.input_checking('kspaceFirstOrder2D')
 
     # =========================================================================

--- a/kwave/kspaceFirstOrder3D.py
+++ b/kwave/kspaceFirstOrder3D.py
@@ -298,11 +298,12 @@ def kspaceFirstOrder3D(
     # start the timer and store the start time
     TicToc.tic()
 
-    if execution_options.is_gpu_simulation:
-        assert simulation_options.save_to_disk, 'GPU simulation requires saving to disk'
-    else:
-        # Currently we only support binary execution, meaning all simulations must be saved to disk.
-        assert simulation_options.save_to_disk, 'CPU simulation requires saving to disk'
+    # Currently we only support binary execution, meaning all simulations must be saved to disk.
+    if not simulation_options.save_to_disk:
+        if execution_options.is_gpu_simulation:
+            raise ValueError('GPU simulation requires saving to disk. Please set SimulationOptions.save_to_disk=True')
+        else:
+            raise ValueError('CPU simulation requires saving to disk. Please set SimulationOptions.save_to_disk=True')
 
     k_sim = kWaveSimulation(
         kgrid=kgrid,

--- a/kwave/kspaceFirstOrder3D.py
+++ b/kwave/kspaceFirstOrder3D.py
@@ -298,6 +298,12 @@ def kspaceFirstOrder3D(
     # start the timer and store the start time
     TicToc.tic()
 
+    if execution_options.is_gpu_simulation:
+        assert simulation_options.save_to_disk, 'GPU simulation requires saving to disk'
+    else:
+        # Currently we only support binary execution, meaning all simulations must be saved to disk.
+        assert simulation_options.save_to_disk, 'CPU simulation requires saving to disk'
+
     k_sim = kWaveSimulation(
         kgrid=kgrid,
         source=source,


### PR DESCRIPTION
Here, I try to add a more explicit error for users who do not set save_to_disk to true.

It could make sense to also try the following:
1. Set default value to True
2. remove save_to_disk as a user setting

This PR also fixes a bug that _always_ runs 2D simulations on the CPU.

closes #238 