### PR TITLE
Upgrade setup-python action & use pip cache

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -90,9 +90,10 @@ jobs:
         run: |
           ls ./tests/matlab_test_data_collectors/python_testers/
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install '.[test]'

--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -12,9 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -e '.[example]'

--- a/.github/workflows/test_pages.yml
+++ b/.github/workflows/test_pages.yml
@@ -5,15 +5,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
     - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         cache: 'pip'
-    - uses: actions/checkout@master
-      with:
-        fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
     - name: Build and Commit
       uses: waltsims/pages@pyproject.toml-support
       with:
         pyproject_toml_deps: ".[docs]"
-        

--- a/.github/workflows/test_pages.yml
+++ b/.github/workflows/test_pages.yml
@@ -5,9 +5,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
+        cache: 'pip'
     - uses: actions/checkout@master
       with:
         fetch-depth: 0 # otherwise, you will fail to push refs to dest repo


### PR DESCRIPTION
Closes #265 

Upgrades `setup-python` actions version from `3` to `5` and enables caching for CI python dependencies to speed up builds. You can read more about the `cache: pip` option [on the `setup-python` documentation](https://github.com/actions/setup-python?tab=readme-ov-file#caching-packages-dependencies). Under the hood, [it uses `toolkit`'s `cache` action](https://github.com/actions/toolkit/tree/main/packages/cache#actionscache).

To check out if the cache works, you can look at the `Install dependencies` step. [Here we do not have the cache](https://github.com/waltsims/k-wave-python/actions/runs/7622744652/job/20761393977) and dependencies are downloaded, while [here we have the cache](https://github.com/waltsims/k-wave-python/actions/runs/7622820196/job/20761620499) and dependencies are pulled from the cache.