### PR TITLE
#262 Fix stdout logic on exceptions

### DIFF
--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -29,20 +29,21 @@ class Executor:
                   f'{options}'
 
         try:
-            with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True) as proc:
-                # Stream stdout in real-time
+            with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True, bufsize=1, universal_newlines=True) as proc:
                 if self.execution_options.show_sim_log:
+                    # Stream stdout in real-time
                     for line in proc.stdout:
                         print(line, end='')
 
-                    proc.wait()
+                proc.wait()
                 if proc.returncode != 0:
-                    raise subprocess.CalledProcessError(proc.returncode, command)
+                    raise subprocess.CalledProcessError(proc.returncode, command,)
+
         except subprocess.CalledProcessError as e:
             if isinstance(e.returncode, unittest.mock.MagicMock):
                 logging.info('Skipping AssertionError in testing.')
             else:
-                print(e.stdout)
+                print(e.stderr)
                 raise
 
         sensor_data = self.parse_executable_output(output_filename)

--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -29,7 +29,7 @@ class Executor:
                   f'{options}'
 
         try:
-            with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True, bufsize=1, universal_newlines=True) as proc:
+            with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True) as proc:
                 if self.execution_options.show_sim_log:
                     # Stream stdout in real-time
                     for line in proc.stdout:
@@ -37,13 +37,13 @@ class Executor:
 
                 proc.wait()
                 if proc.returncode != 0:
-                    raise subprocess.CalledProcessError(proc.returncode, command,)
+                    raise subprocess.CalledProcessError(proc.returncode, command)
 
         except subprocess.CalledProcessError as e:
             if isinstance(e.returncode, unittest.mock.MagicMock):
                 logging.info('Skipping AssertionError in testing.')
             else:
-                print(e.stderr)
+                print(e.stdout)
                 raise
 
         sensor_data = self.parse_executable_output(output_filename)

--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -30,19 +30,24 @@ class Executor:
 
         try:
             with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True) as proc:
+                stdout, stderr = "", ""
                 if self.execution_options.show_sim_log:
                     # Stream stdout in real-time
                     for line in proc.stdout:
                         print(line, end='')
+                else:
+                    stdout, stderr = proc.communicate()  
 
-                proc.wait()
+                proc.wait() # wait for process to finish before checking return code
                 if proc.returncode != 0:
-                    raise subprocess.CalledProcessError(proc.returncode, command)
+                    raise subprocess.CalledProcessError(proc.returncode, command, stdout, stderr)
 
         except subprocess.CalledProcessError as e:
+            # Special handling for MagicMock during testing
             if isinstance(e.returncode, unittest.mock.MagicMock):
                 logging.info('Skipping AssertionError in testing.')
             else:
+                # This ensures stdout is printed regardless of show_sim_logs value if an error occurs
                 print(e.stdout)
                 raise
 

--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -28,14 +28,17 @@ class Executor:
                   f'-o {output_filename} ' \
                   f'{options}'
 
-        stdout = None if self.execution_options.show_sim_log else subprocess.DEVNULL
         try:
-            subprocess.run(command, stdout=stdout, shell=True, check=True)
+            result = subprocess.run(command, capture_output=True, shell=True, check=True, text=True)
         except subprocess.CalledProcessError as e:
             if isinstance(e.returncode, unittest.mock.MagicMock):
                 logging.info('Skipping AssertionError in testing.')
             else:
-                raise
+                print(e.stdout) 
+                raise  
+        else:
+            if self.execution_options.show_sim_log:
+                print(result.stdout)
 
         sensor_data = self.parse_executable_output(output_filename)
 


### PR DESCRIPTION
close #262 

This PR ensures that the stdout from the k-wave binary is printed if an error is raised. The first commit captures the output and displays it immediately upon completion. The final commit streams the output to the console.