### PR TITLE
Remove duplicate write_attributes_typed function

### DIFF
--- a/kwave/kWaveSimulation_helper/save_to_disk_func.py
+++ b/kwave/kWaveSimulation_helper/save_to_disk_func.py
@@ -488,7 +488,7 @@ def save_h5_file(filepath, integer_variables, float_variables, hdf_compression_l
         del value
 
     # set additional file attributes
-    write_attributes(filepath, legacy=True)  # TODO: update to currently breaking code after references are updated
+    write_attributes(filepath)
 
 
 def save_mat_file(filepath, integer_variables, float_variables):

--- a/kwave/utils/io.py
+++ b/kwave/utils/io.py
@@ -199,38 +199,8 @@ def write_matrix(filename, matrix: np.ndarray, matrix_name: str, compression_lev
         assign_str_attr(f[f'/{matrix_name}'].attrs, h5_literals.DATA_TYPE_ATT_NAME, data_type_c)
 
 
-def write_attributes_typed(filename, file_description=None):
-    # get literals
-    h5_literals = get_h5_literals()
 
-    # get computer infor
-    comp_info = dotdict({
-        'date': datetime.now().strftime("%d-%b-%Y"),
-        'computer_name': socket.gethostname(),
-        'operating_system_type': platform.system(),
-        'operating_system': platform.system() + " " + platform.release() + " " + platform.version(),
-        'user_name': os.environ.get('USERNAME'),
-        'matlab_version': 'N/A',
-        'kwave_version': '1.3',
-        'kwave_path': 'N/A',
-    })
-
-    # set file description if not provided by user
-    if file_description is None:
-        file_description = f'Input data created by {comp_info.user_name} running MATLAB ' \
-                           f'{comp_info.matlab_version} on {comp_info.operating_system_type}'
-
-    # set additional file attributes
-    with h5py.File(filename, "a") as f:
-        f[h5_literals.FILE_MAJOR_VER_ATT_NAME] = h5_literals.HDF_FILE_MAJOR_VERSION
-        f[h5_literals.FILE_MINOR_VER_ATT_NAME] = h5_literals.HDF_FILE_MINOR_VERSION
-        f[h5_literals.CREATED_BY_ATT_NAME] = 'k-Wave 1.3'
-        f[h5_literals.FILE_DESCR_ATT_NAME] = file_description
-        f[h5_literals.FILE_TYPE_ATT_NAME] = h5_literals.HDF_INPUT_FILE
-        f[h5_literals.FILE_CREATION_DATE_ATT_NAME] = get_date_string()
-
-
-def write_attributes(filename: str, file_description: Optional[str] = None, legacy: bool = False) -> None:
+def write_attributes(filename: str, file_description: Optional[str] = None) -> None:
     """
     Write attributes to a HDF5 file.
 
@@ -242,17 +212,11 @@ def write_attributes(filename: str, file_description: Optional[str] = None, lega
         filename: The name of the HDF5 file.
         file_description: The description of the file. If not provided, a default description
             will be used.
-        legacy: If set to True, the function will use the deprecated legacy method to write attributes.
-            If set to False, the function will use the new typed method. Defaults to False.
 
     Raises:
         DeprecationWarning: If legacy is set to True, a DeprecationWarning will be raised.
 
     """
-
-    if not legacy:
-        write_attributes_typed(filename, file_description)
-        return
 
     logging.log(logging.WARN, f'{DeprecationWarning.__name__}: Attributes will soon be typed when saved and not saved ')
     # get literals

--- a/tests/matlab_test_data_collectors/python_testers/h5io_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/h5io_test.py
@@ -10,9 +10,11 @@ from kwave.utils.io import write_matrix, write_attributes, write_grid, write_fla
 def compare_h5_attributes(local_h5_path, ref_path):
     local_h5 = h5py.File(local_h5_path, 'r')
     ref_h5 = h5py.File(ref_path, 'r')
+    keys_to_ignore = ['created_by', 'creation_date', 'file_description']
     for key in local_h5.attrs.keys():
-        assert key in ref_h5.attrs.keys()
-        assert np.isclose(local_h5.attrs[key], ref_h5.attrs[key])
+        if key not in keys_to_ignore:
+            assert key in ref_h5.attrs.keys()
+            assert str(local_h5.attrs[key]) == str(ref_h5.attrs[key])
 
 
 def compare_h5_values(local_h5_path, ref_path):

--- a/tests/test_cpp_io_in_parts.py
+++ b/tests/test_cpp_io_in_parts.py
@@ -254,7 +254,7 @@ def test_cpp_io_in_parts():
         write_flags(input_file_full_path)
 
         # set additional file attributes
-        write_attributes(input_file_full_path, legacy=True)
+        write_attributes(input_file_full_path)
 
         TicToc.toc()
 


### PR DESCRIPTION
Fixes #253 

This is a follow up PR of https://github.com/waltsims/k-wave-python/pull/289 which we ended up reverting because examples were broken. We had a second look to our approach and turns out we don't need the new `write_attributes_typed` function. Furthermore, the approach used in the `write_attributes_typed` is not correct because kWave binaries expect attributes in the HDF5 file attributes field.

This PR removes the `write_attributes_typed` function and makes sure that we always use `write_attributes` function.