### PR TITLE
Fix binary file redownloading on windows

### DIFF
--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -118,8 +118,8 @@ def _is_binary_present(binary_name: str, binary_type: str) -> bool:
         return False
     
     # If there is a new binary
-    latest_url = url_dict[system][binary_type][0]
-    if existing_metadata['url'] != latest_url:
+    latest_urls = url_dict[system][binary_type]
+    if existing_metadata['url'] not in latest_urls:
         return False
     
     # No need to check `version` field for now


### PR DESCRIPTION
Updates `_is_binary_present` to search through all urls, rather than comparing for only the first item in the list.

Closes #366