### PR TITLE
Minor Typo fix - US BMode Phased Array Example

### DIFF
--- a/examples/us_bmode_phased_array/us_bmode_phased_array.ipynb
+++ b/examples/us_bmode_phased_array/us_bmode_phased_array.ipynb
@@ -394,7 +394,7 @@
     "plt.figure(figsize=(15, 4))\n",
     "plt.subplot(131)\n",
     "plt.imshow(scan_lines.T, aspect='auto',\n",
-    "             extent=[steering_angles[-1], steering_angles[0],y_axis[1], y_axis[0] ], interpolation='none', cmap='grey')\n",
+    "             extent=[steering_angles[-1], steering_angles[0],y_axis[1], y_axis[0] ], interpolation='none', cmap='gray')\n",
     "plt.xlabel('Steering angle [deg]')\n",
     "plt.ylabel('Depth [mm]')\n",
     "plt.title('Raw Scan-Line Data')\n",

--- a/examples/us_bmode_phased_array/us_bmode_phased_array.py
+++ b/examples/us_bmode_phased_array/us_bmode_phased_array.py
@@ -229,7 +229,7 @@ plt.ion()
 plt.figure(figsize=(15, 4))
 plt.subplot(131)
 plt.imshow(
-    scan_lines.T, aspect="auto", extent=[steering_angles[-1], steering_angles[0], y_axis[1], y_axis[0]], interpolation="none", cmap="grey"
+    scan_lines.T, aspect="auto", extent=[steering_angles[-1], steering_angles[0], y_axis[1], y_axis[0]], interpolation="none", cmap="gray"
 )
 plt.xlabel("Steering angle [deg]")
 plt.ylabel("Depth [mm]")


### PR DESCRIPTION
Small change, the cmap is 'gray' not 'grey'. Produces an error. Fixing this typo.