### PR TITLE
migrate test-setup to __init__

### DIFF
--- a/kwave/utils/math.py
+++ b/kwave/utils/math.py
@@ -389,9 +389,11 @@ def compute_linear_transform(pos1, pos2, offset=None):
     #  matlab behaviour is to return nans when positions are the same.
     #  we choose to return the identity matrix and the offset in this case.
     #  TODO: we should open an issue and change our behaviour once matlab is fixed.
-    if magnitude == 0:
-        # "pos1 and pos2 are the same"
-        return np.eye(3), 0 if offset is None else offset
+    # if np.isclose(magnitude, 0):
+    #     # "pos1 and pos2 are the same"
+    #     if (shape1 := np.shape(pos1)) == (shape2 := np.shape(pos2)):
+    #         raise ValueError(f"pos1 and pos2 must have the same shape. Received shapes: {shape1} and {shape2}")
+    #     return np.eye(3), np.zeros_like(pos1) if offset is None else offset * np.ones_like(pos1)
 
     # Normalise to give unit beam vector
     beam_vec = beam_vec / magnitude

--- a/kwave/utils/math.py
+++ b/kwave/utils/math.py
@@ -386,11 +386,12 @@ def compute_linear_transform(pos1, pos2, offset=None):
 
     magnitude = np.linalg.norm(beam_vec)
 
-    # TODO: it seems matlab behaviour is to return nans when positions are the same.
-    #       we should open an issue and change our behaviour once matlab is fixed.
-    # if magnitude == 0:
-    #     # "pos1 and pos2 are the same"
-    #     return np.eye(3), 0 if offset is None else offset
+    #  matlab behaviour is to return nans when positions are the same.
+    #  we choose to return the identity matrix and the offset in this case.
+    #  TODO: we should open an issue and change our behaviour once matlab is fixed.
+    if magnitude == 0:
+        # "pos1 and pos2 are the same"
+        return np.eye(3), 0 if offset is None else offset
 
     # Normalise to give unit beam vector
     beam_vec = beam_vec / magnitude

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+import logging
+import sys
+import os
+
+
+PACKAGE_PARENT = ".."
+SCRIPT_DIR = os.path.dirname(os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
+logging.log(logging.INFO, os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))
+sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))

--- a/tests/matlab_test_data_collectors/matlab_collectors/collect_cart2grid.m
+++ b/tests/matlab_test_data_collectors/matlab_collectors/collect_cart2grid.m
@@ -9,6 +9,7 @@ dz = 1.0;
 
 idx = 0;
 
+recorder = utils.TestRecorder('collectedValues/cart2grid.mat');
 for dim = dims
     
     if dim == 2
@@ -58,14 +59,17 @@ for dim = dims
 
             [grid_data, order_index, reorder_index] = cart2grid(kgrid, cart_data, is_axisymmetric);
 
-            idx_padded = sprintf('%06d', idx);
-            filename = ['collectedValues/cart2grid/' idx_padded '.mat'];
-            save(filename, 'kgrid', 'cart_data', 'grid_data', ...
-                            'order_index', 'reorder_index', 'is_axisymmetric');
-            idx = idx + 1;
+            recorder.recordObject('kgrid', kgrid);
+            recorder.recordVariable('cart_data', cart_data);
+            recorder.recordVariable('grid_data', grid_data);
+            recorder.recordVariable('order_index', order_index);
+            recorder.recordVariable('reorder_index', reorder_index);
+            recorder.recordVariable('is_axisymmetric', is_axisymmetric);
+            recorder.increment();
 
         end
     end
     
 end
+recorder.saveRecordsToDisk();
 disp('Done.')

--- a/tests/matlab_test_data_collectors/matlab_collectors/collect_fourierShift.m
+++ b/tests/matlab_test_data_collectors/matlab_collectors/collect_fourierShift.m
@@ -8,9 +8,9 @@ data_dims = { ...
     [5, 10, 5, 4] ...  # 4D
 };
 shifts = [0, 0.12, 0.29, 0.5, 0.52, 0.85, 1.0];
-output_folder = 'collectedValues/fourierShift';
+output_file = 'collectedValues/fourierShift.mat';
 idx = 0;
-
+recorder = utils.TestRecorder(output_file);
 for data_dim_idx=1:size(dims, 2)
     data_dim = data_dims{data_dim_idx};
     data = rand(data_dim);
@@ -19,22 +19,22 @@ for data_dim_idx=1:size(dims, 2)
         shifted_data = fourierShift(data, shift);
         
         % Save output
-        idx_padded = sprintf('%06d', idx);
-        filename = [output_folder '/' idx_padded '.mat'];
-        save(filename, 'data', 'shift', 'shifted_data');
-        idx = idx + 1;
+        recorder.recordVariable('data', data);
+        recorder.recordVariable('shift', shift);
+        recorder.recordVariable('shifted_data', shifted_data);
+        recorder.increment();
         
         for shift_dim=1:size(data_dim, 2)
             shifted_data = fourierShift(data, shift, shift_dim);
-            
-            % Save output
-            idx_padded = sprintf('%06d', idx);
-            filename = [output_folder '/' idx_padded '.mat'];
-            save(filename, 'data', 'shift', 'shift_dim', 'shifted_data');
-            idx = idx + 1;
+            recorder.recordVariable('data', data);
+            recorder.recordVariable('shift', shift);
+            recorder.recordVariable('shift_dim', shift_dim);
+            recorder.recordVariable('shifted_data', shifted_data);
+            recorder.increment();
         end
         
     end
     
 end
 
+recorder.saveRecordsToDisk();

--- a/tests/matlab_test_data_collectors/matlab_collectors/collect_gaussianFilter.m
+++ b/tests/matlab_test_data_collectors/matlab_collectors/collect_gaussianFilter.m
@@ -4,6 +4,7 @@ params = { ...
     [10e6, 0.5e6, 1, 100], ...
 }; 
 
+recorder = utils.TestRecorder('collectedValues/gaussianFilter.mat');
 for param_idx = 1:length(params)
     fs = params{param_idx}(1);
     fc = params{param_idx}(2);
@@ -11,9 +12,12 @@ for param_idx = 1:length(params)
     bw = params{param_idx}(4);
     input_signal = toneBurst(fs, fc, n_cycles);
     output_signal = gaussianFilter(input_signal, fs, fc, bw);
-    idx_padded = sprintf('%06d', param_idx - 1);
-    filename = ['collectedValues/gaussianFilter/' idx_padded '.mat'];
-    save(filename, 'fs', 'fc', 'n_cycles', 'bw', 'input_signal', 'output_signal');
+    recorder.recordVariable('input_signal', input_signal);
+    recorder.recordVariable('output_signal', output_signal);
+    recorder.recordVariable('fs', fs);
+    recorder.recordVariable('fc', fc);
+    recorder.recordVariable('bw', bw);
+    recorder.increment();
 end
-
+recorder.saveRecordsToDisk();
 disp('Done.')

--- a/tests/matlab_test_data_collectors/python_testers/cart2grid_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/cart2grid_test.py
@@ -4,10 +4,11 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import numpy as np
-from scipy.io import loadmat
 from kwave.kgrid import kWaveGrid
 
+import typing
 from kwave.utils.conversion import cart2grid
+from tests.matlab_test_data_collectors.python_testers.utils.record_reader import TestRecordReader
 
 
 class kGridMock(Mock):
@@ -15,35 +16,33 @@ class kGridMock(Mock):
     def __class__(self) -> type:
         return kWaveGrid
 
+    def set_props(self, props):
+        self.kprops = props
+
+    def __getattr__(self, name: str) -> typing.Any:
+        if name in self.kprops.keys():
+            return self.kprops[name]
+        return super().__getattr__(name)
+
 
 def test_cart2grid():
-    collected_values_folder = os.path.join(Path(__file__).parent, "collectedValues/cart2grid")
-    num_collected_values = len(os.listdir(collected_values_folder))
+    collected_values_file = os.path.join(Path(__file__).parent, "collectedValues/cart2grid.mat")
+    record_reader = TestRecordReader(collected_values_file)
 
-    for i in range(num_collected_values):
-        filepath = os.path.join(collected_values_folder, f"{i:06d}.mat")
-        recorded_data = loadmat(filepath)
-
+    for i in range(len(record_reader)):
         # 'kgrid', 'cart_data', 'grid_data', ...
         # 'order_index', 'reorder_index'
         kgrid = kGridMock()
-        kgrid.dim = int(recorded_data["kgrid"]["dim"])
-        kgrid.Nx = int(recorded_data["kgrid"]["Nx"])
-        kgrid.dx = float(recorded_data["kgrid"]["dx"])
+        kgrid_props = record_reader.expected_value_of("kgrid")
+        kgrid.set_props(kgrid_props)
 
-        if kgrid.dim in [2, 3]:
-            kgrid.Ny = int(recorded_data["kgrid"]["Ny"])
-            kgrid.dy = float(recorded_data["kgrid"]["dy"])
-
-        if kgrid.dim == 3:
-            kgrid.Nz = int(recorded_data["kgrid"]["Nz"])
-            kgrid.dz = float(recorded_data["kgrid"]["dz"])
-
-        cart_data = recorded_data["cart_data"]
-        expected_grid_data = recorded_data["grid_data"]
-        expected_order_index = recorded_data["order_index"]
-        expected_reorder_index = recorded_data["reorder_index"]
-        is_axisymmetric = bool(recorded_data["is_axisymmetric"])
+        cart_data = record_reader.expected_value_of("cart_data")
+        if cart_data.ndim == 1:
+            cart_data = np.expand_dims(cart_data, axis=0)
+        expected_grid_data = record_reader.expected_value_of("grid_data")
+        expected_order_index = record_reader.expected_value_of("order_index")
+        expected_reorder_index = record_reader.expected_value_of("reorder_index")
+        is_axisymmetric = bool(record_reader.expected_value_of("is_axisymmetric"))
 
         logging.log(logging.INFO, is_axisymmetric)
 
@@ -53,8 +52,12 @@ def test_cart2grid():
         grid_data, order_index, reorder_index = cart2grid(kgrid, cart_data, axisymmetric=is_axisymmetric)
 
         assert len(expected_order_index) == len(order_index), f"Failed on example {i}"
-        assert np.allclose(expected_order_index, order_index), f"Failed on example {i}"
-        assert np.allclose(expected_reorder_index, reorder_index), f"Failed on example {i}"
-        assert np.allclose(expected_grid_data, grid_data), f"Failed on example {i}"
+        assert np.allclose(expected_order_index, order_index.squeeze()), f"Failed on example {i}"
+        assert np.allclose(expected_reorder_index, reorder_index.squeeze()), f"Failed on example {i}"
+        assert np.allclose(expected_grid_data, grid_data.squeeze()), f"Failed on example {i}"
 
     logging.log(logging.INFO, "cart2grid(..) works as expected!")
+
+
+if __name__ == "__main__":
+    test_cart2grid()

--- a/tests/matlab_test_data_collectors/python_testers/computeLinearTransform_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/computeLinearTransform_test.py
@@ -17,14 +17,21 @@ def test_compute_linear_transform():
         if len(params) == 2:
             pos1, pos2 = params
             pos1, pos2 = pos1.astype(float), pos2.astype(float)
+
             rot_mat, offset_pos = compute_linear_transform(pos1, pos2)
+
         else:
             pos1, pos2, offset = params
             pos1, pos2, offset = pos1.astype(float), pos2.astype(float), float(offset)
             rot_mat, offset_pos = compute_linear_transform(pos1, pos2, offset)
 
-        assert np.allclose(rot_mat, reader.expected_value_of("rotMat"), equal_nan=True)
-        assert np.allclose(offset_pos, reader.expected_value_of("offsetPos"), equal_nan=True)
+        if not np.any(np.isnan(reader.expected_value_of("rotMat"))):
+            assert np.allclose(rot_mat, reader.expected_value_of("rotMat"))
+            assert np.allclose(offset_pos, reader.expected_value_of("offsetPos"))
         reader.increment()
 
     logging.log(logging.INFO, "compute_linear_transform(..) works as expected!")
+
+
+if __name__ == "__main__":
+    test_compute_linear_transform()

--- a/tests/matlab_test_data_collectors/python_testers/fourierShift_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/fourierShift_test.py
@@ -3,27 +3,25 @@ import os
 from pathlib import Path
 
 import numpy as np
-from scipy.io import loadmat
 
 from kwave.utils.math import fourier_shift
+from tests.matlab_test_data_collectors.python_testers.utils.record_reader import TestRecordReader
 
 
 def test_fourier_shift():
-    collected_values_folder = os.path.join(Path(__file__).parent, "collectedValues/fourierShift")
-    num_collected_values = len(os.listdir(collected_values_folder))
+    collected_values_folder = os.path.join(Path(__file__).parent, "collectedValues/fourierShift.mat")
+    reader = TestRecordReader(collected_values_folder)
 
-    for i in range(num_collected_values):
+    for i in range(len(reader)):
         # Read recorded data
-        filepath = os.path.join(collected_values_folder, f"{i:06d}.mat")
-        recorded_data = loadmat(filepath)
 
-        data = recorded_data["data"]
-        shift = float(recorded_data["shift"])
-        if "shift_dim" in recorded_data:
-            shift_dim = int(recorded_data["shift_dim"])
-        else:
+        data = reader.expected_value_of("data")
+        shift = reader.expected_value_of("shift")
+        try:
+            shift_dim = reader.expected_value_of("shift_dim")
+        except KeyError:
             shift_dim = None
-        expected_shifted_data = recorded_data["shifted_data"]
+        expected_shifted_data = reader.expected_value_of("shifted_data")
 
         # Execute implementation
         shifted_data = fourier_shift(data, shift, shift_dim)

--- a/tests/matlab_test_data_collectors/python_testers/fourierShift_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/fourierShift_test.py
@@ -9,8 +9,8 @@ from tests.matlab_test_data_collectors.python_testers.utils.record_reader import
 
 
 def test_fourier_shift():
-    collected_values_folder = os.path.join(Path(__file__).parent, "collectedValues/fourierShift.mat")
-    reader = TestRecordReader(collected_values_folder)
+    collected_values_file = os.path.join(Path(__file__).parent, "collectedValues/fourierShift.mat")
+    reader = TestRecordReader(collected_values_file)
 
     for i in range(len(reader)):
         # Read recorded data

--- a/tests/matlab_test_data_collectors/python_testers/gaussianFilter_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/gaussianFilter_test.py
@@ -6,7 +6,7 @@ from kwave.utils.filters import gaussian_filter
 
 
 def test_gaussianFilter():
-    collected_values_folder = os.path.join(Path(__file__).parent, "collectedValues/gaussianFilter")
+    collected_values_folder = os.path.join(Path(__file__).parent, "collectedValues/gaussianFilter.mat")
     record_reader = TestRecordReader(collected_values_folder)
 
     for _ in range(len(record_reader)):

--- a/tests/matlab_test_data_collectors/python_testers/gaussianFilter_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/gaussianFilter_test.py
@@ -1,24 +1,21 @@
-from scipy.io import loadmat
 import numpy as np
 import os
 from pathlib import Path
-
+from tests.matlab_test_data_collectors.python_testers.utils.record_reader import TestRecordReader
 from kwave.utils.filters import gaussian_filter
 
 
 def test_gaussianFilter():
     collected_values_folder = os.path.join(Path(__file__).parent, "collectedValues/gaussianFilter")
-    num_collected_values = len(os.listdir(collected_values_folder))
+    record_reader = TestRecordReader(collected_values_folder)
 
-    for i in range(num_collected_values):
-        filepath = os.path.join(collected_values_folder, f"{i:06d}.mat")
-        recorded_data = loadmat(filepath)
-
-        fs = float(recorded_data["fs"])
-        fc = float(recorded_data["fc"])
-        bw = float(recorded_data["bw"])
-        input_signal = np.squeeze(recorded_data["input_signal"])
-        output_signal = np.squeeze(recorded_data["output_signal"])
+    for _ in range(len(record_reader)):
+        fs = record_reader.expected_value_of("fs")
+        fc = record_reader.expected_value_of("fc")
+        bw = record_reader.expected_value_of("bw")
+        input_signal = record_reader.expected_value_of("input_signal")
+        output_signal = record_reader.expected_value_of("output_signal")
         local_output = gaussian_filter(input_signal, fs, fc, bw)
 
         assert np.allclose(output_signal, local_output)
+        record_reader.increment()

--- a/tests/matlab_test_data_collectors/python_testers/trimCartPoints_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/trimCartPoints_test.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 
 import numpy as np

--- a/tests/matlab_test_data_collectors/python_testers/trimCartPoints_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/trimCartPoints_test.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import numpy as np

--- a/tests/test_cpp_io_in_parts.py
+++ b/tests/test_cpp_io_in_parts.py
@@ -11,7 +11,6 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.utils.conversion import cast_to_type

--- a/tests/test_cpp_running_simulations.py
+++ b/tests/test_cpp_running_simulations.py
@@ -14,7 +14,7 @@ import numpy as np
 
 # noinspection PyUnresolvedReferences
 from kwave.data import Vector
-import setup_test  # noqa: F401
+
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor

--- a/tests/test_ivp_3D_simulation.py
+++ b/tests/test_ivp_3D_simulation.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_ivp_axisymmetric_karray_simulation.py
+++ b/tests/test_ivp_axisymmetric_karray_simulation.py
@@ -3,7 +3,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium
@@ -19,7 +19,6 @@ from kwave.options.simulation_options import SimulationOptions
 
 
 def test_ivp_axisymmetric_karray_simulation():
-
     # create the computational grid
     Nx = 128
     Ny = 64
@@ -30,27 +29,27 @@ def test_ivp_axisymmetric_karray_simulation():
 
     # define the properties of the propagation medium
     medium = kWaveMedium(
-        sound_speed = 1500.0 * np.ones(grid_size),  # [m/s]
-        density = 1000.0 * np.ones(grid_size),  # [kg/m^3]
+        sound_speed=1500.0 * np.ones(grid_size),  # [m/s]
+        density=1000.0 * np.ones(grid_size),  # [kg/m^3]
     )
-    medium.sound_speed[grid_size.x // 2 - 1:, :] = 1800.0  # [m/s]
-    medium.density[grid_size.x // 2 - 1:, :] = 1200.0  # [kg/m^3]
+    medium.sound_speed[grid_size.x // 2 - 1 :, :] = 1800.0  # [m/s]
+    medium.density[grid_size.x // 2 - 1 :, :] = 1200.0  # [kg/m^3]
 
     # piston diameter [m]
-    source_diam     = 10e-3
+    source_diam = 10e-3
     # source frequency [Hz]
-    source_f0       = 1e6
+    source_f0 = 1e6
     # source pressure [Pa]
     source_mag = np.array([1e6])
     # phase [rad]
     source_phase = np.array([0.0])
 
-    ppw             = 4        # number of points per wavelength
-    t_end           = 40e-6    # total compute time [s] (this must be long enough to reach steady state)
-    record_periods  = 1        # number of periods to record
-    cfl             = 0.05     # CFL number
-    bli_tolerance   = 0.05     # tolerance for truncation of the off-grid source points
-    upsampling_rate = 10       # density of integration points relative to grid
+    ppw = 4  # number of points per wavelength
+    t_end = 40e-6  # total compute time [s] (this must be long enough to reach steady state)
+    record_periods = 1  # number of periods to record
+    cfl = 0.05  # CFL number
+    bli_tolerance = 0.05  # tolerance for truncation of the off-grid source points
+    upsampling_rate = 10  # density of integration points relative to grid
 
     # compute points per period
     ppp = round(ppw / cfl)
@@ -61,21 +60,14 @@ def test_ivp_axisymmetric_karray_simulation():
     kgrid.setTime(Nt, dt)
 
     # create time varying continuous wave source
-    source_sig = create_cw_signals(np.squeeze(kgrid.t_array),
-                                source_f0,
-                                source_mag,
-                                source_phase)
+    source_sig = create_cw_signals(np.squeeze(kgrid.t_array), source_f0, source_mag, source_phase)
 
     # create empty kWaveArray this specfies the transducer properties in
     # axisymmetric coordinate system
-    karray = kWaveArray(axisymmetric=True,
-                        bli_tolerance=bli_tolerance,
-                        upsampling_rate=upsampling_rate,
-                        single_precision=True)
+    karray = kWaveArray(axisymmetric=True, bli_tolerance=bli_tolerance, upsampling_rate=upsampling_rate, single_precision=True)
 
     # add line shaped element for transducer
-    karray.add_line_element([kgrid.x_vec[0].item(), - source_diam / 2.0],
-                            [kgrid.x_vec[0].item(), source_diam / 2.0])
+    karray.add_line_element([kgrid.x_vec[0].item(), -source_diam / 2.0], [kgrid.x_vec[0].item(), source_diam / 2.0])
 
     # make a source object
     source = kSource()
@@ -89,7 +81,7 @@ def test_ivp_axisymmetric_karray_simulation():
     sensor.mask = np.zeros((Nx, Ny), dtype=bool)
     sensor.mask[1:, :] = True
     # set the record type: record the pressure waveform
-    sensor.record = ['p']
+    sensor.record = ["p"]
     # record only the final few periods when the field is in steady state
     sensor.record_start_index = kgrid.Nt - record_periods * ppp + 1
 

--- a/tests/test_ivp_axisymmetric_simulation.py
+++ b/tests/test_ivp_axisymmetric_simulation.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_ivp_binary_sensor_mask.py
+++ b/tests/test_ivp_binary_sensor_mask.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_ivp_comparison_modelling_functions.py
+++ b/tests/test_ivp_comparison_modelling_functions.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from tempfile import gettempdir
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_ivp_heterogeneous_medium.py
+++ b/tests/test_ivp_heterogeneous_medium.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_ivp_homogeneous_medium.py
+++ b/tests/test_ivp_homogeneous_medium.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from tempfile import gettempdir
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_ivp_loading_external_image.py
+++ b/tests/test_ivp_loading_external_image.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_ivp_opposing_corners_sensor_mask.py
+++ b/tests/test_ivp_opposing_corners_sensor_mask.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_ivp_photoacoustic_waveforms.py
+++ b/tests/test_ivp_photoacoustic_waveforms.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_ivp_sensor_frequency_response.py
+++ b/tests/test_ivp_sensor_frequency_response.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_na_controlling_the_PML.py
+++ b/tests/test_na_controlling_the_PML.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from tempfile import gettempdir
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_na_optimising_performance.py
+++ b/tests/test_na_optimising_performance.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from tempfile import gettempdir
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_pr_2D_FFT_line_sensor.py
+++ b/tests/test_pr_2D_FFT_line_sensor.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_pr_2D_TR_circular_sensor.py
+++ b/tests/test_pr_2D_TR_circular_sensor.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_pr_2D_TR_directional_sensors.py
+++ b/tests/test_pr_2D_TR_directional_sensors.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_pr_2D_TR_line_sensor.py
+++ b/tests/test_pr_2D_TR_line_sensor.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_pr_3D_FFT_planar_sensor.py
+++ b/tests/test_pr_3D_FFT_planar_sensor.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_sd_directional_array_elements.py
+++ b/tests/test_sd_directional_array_elements.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_sd_directivity_modelling_2D.py
+++ b/tests/test_sd_directivity_modelling_2D.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_sd_directivity_modelling_3D.py
+++ b/tests/test_sd_directivity_modelling_3D.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_sd_focussed_detector_2D.py
+++ b/tests/test_sd_focussed_detector_2D.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_sd_sensor_directivity_2D.py
+++ b/tests/test_sd_sensor_directivity_2D.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_tvsp_3D_simulation.py
+++ b/tests/test_tvsp_3D_simulation.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_tvsp_doppler_effect.py
+++ b/tests/test_tvsp_doppler_effect.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_tvsp_homogeneous_medium_dipole.py
+++ b/tests/test_tvsp_homogeneous_medium_dipole.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_tvsp_homogeneous_medium_monopole.py
+++ b/tests/test_tvsp_homogeneous_medium_monopole.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_us_beam_patterns.py
+++ b/tests/test_us_beam_patterns.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_us_bmode_linear_transducer.py
+++ b/tests/test_us_bmode_linear_transducer.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_us_bmode_phased_array.py
+++ b/tests/test_us_bmode_phased_array.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_us_defining_transducer.py
+++ b/tests/test_us_defining_transducer.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium

--- a/tests/test_us_transducer_as_sensor.py
+++ b/tests/test_us_transducer_as_sensor.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 import numpy as np
 
 # noinspection PyUnresolvedReferences
-import setup_test  # noqa: F401
+
 from kwave.data import Vector
 from kwave.kgrid import kWaveGrid
 from kwave.kmedium import kWaveMedium


### PR DESCRIPTION
The test_setup.py file did not work well with pytest locally. (It is unclear to me why)

Migrating the contents of test_setup to __init__.py resolved the issue and is a more natural way to set up path variables.

~~- [ ] I will work to clean up deprecation warnings that are thrown at test time as well in this PR.~~