### PR TITLE
Only test installation when pyproject.toml is updated

### DIFF
--- a/.github/workflows/test_optional_dependencies.yml
+++ b/.github/workflows/test_optional_dependencies.yml
@@ -1,23 +1,29 @@
 name: test_optional_requirements
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'pyproject.toml'
+  pull_request:
+    paths:
+      - 'pyproject.toml'
 
 jobs:
-    test_install:
-        strategy:
-            matrix:
-                os: [ "windows-latest", "ubuntu-latest" ] #, "macos-latest"]
-                python-version: [ "3.9", "3.10", "3.11", "3.12" ]
-                extra_requirements: [ "test", "examples", "docs", "dev", "all" ]
-        runs-on: ${{matrix.os}}
-        steps:
-            - uses: actions/checkout@v4
-            # Pull the cache based on the hash value
-            - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ matrix.python-version }}
-                  cache: 'pip'
-            - name: Install dependencies
-              run: |
-                  pip install '.[${{ matrix.extra_requirements }}]'
+  test_install:
+    strategy:
+      matrix:
+        os: [ "windows-latest", "ubuntu-latest" ] #, "macos-latest"]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        extra_requirements: [ "test", "examples", "docs", "dev", "all" ]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v4
+      # Pull the cache based on the hash value
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install '.[${{ matrix.extra_requirements }}]'


### PR DESCRIPTION
The installation tests take up quite a lot of time for the CI. This change modifies the workflow only to run when the pyproject.toml file has been modified.