### PR TITLE
create new map for every recorder object and clear vars

### DIFF
--- a/tests/matlab_test_data_collectors/matlab_collectors/+utils/TestRecorder.m
+++ b/tests/matlab_test_data_collectors/matlab_collectors/+utils/TestRecorder.m
@@ -1,12 +1,13 @@
 classdef TestRecorder < handle
    properties
       record_filename = ""
-      records = containers.Map
+      records
       step = 0
    end
    methods
        
        function obj = TestRecorder(record_filename)
+           obj.records = containers.Map;
            obj.record_filename = record_filename;
        end
        

--- a/tests/matlab_test_data_collectors/matlab_collectors/collect_reorderSensorData.m
+++ b/tests/matlab_test_data_collectors/matlab_collectors/collect_reorderSensorData.m
@@ -9,7 +9,7 @@ for i=1:20
     mask(randi(mask_size(1)), randi(mask_size(2))) = 1;
 end
 sensor = struct('mask', mask);
-
+sensor_data = rand(sensor_data_size);
 kgrid = kWaveGrid(kgrid_size(1), kgrid_dx_dy, kgrid_size(2), kgrid_dx_dy);
 reordered_sensor_data = reorderSensorData(kgrid, sensor, sensor_data);
 

--- a/tests/matlab_test_data_collectors/run_all_collectors.m
+++ b/tests/matlab_test_data_collectors/run_all_collectors.m
@@ -12,6 +12,7 @@ for idx=1:length(files)
         mkdir(collected_value_dir)
         % run value collector
         run(fullfile(directory, files{idx}));
+        clearvars -except idx files directory
 end
 
 if ~isRunningInCI()


### PR DESCRIPTION
This commits ensure that all variables are cleared for every collection script and that the recorder object is reinitialized inorder to clear memory of past objects variables.