### PR TITLE
Small bug fixes

### DIFF
--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -85,7 +85,7 @@ class Executor:
         with h5py.File(output_filename, "r") as output_file:
             sensor_data = {}
             for key in output_file.keys():
-                sensor_data[key] = output_file[f"/{key}"][0].squeeze()
+                sensor_data[key] = output_file[f"/{key}"][:].squeeze()
         #     if self.simulation_options.cuboid_corners:
         #         sensor_data = [output_file[f'/p/{index}'][()] for index in range(1, len(key['mask']) + 1)]
         #

--- a/kwave/kWaveSimulation.py
+++ b/kwave/kWaveSimulation.py
@@ -161,7 +161,7 @@ class kWaveSimulation(object):
         """
         fields = ["p", "p_max", "p_min", "p_rms", "u", "u_non_staggered", "u_split_field", "u_max", "u_min", "u_rms", "I", "I_avg"]
         if not any(self.record.is_set(fields)) and not self.time_rev:
-            return False
+            return True
         return False
 
     @property

--- a/kwave/kWaveSimulation.py
+++ b/kwave/kWaveSimulation.py
@@ -160,7 +160,7 @@ class kWaveSimulation(object):
 
         """
         fields = ["p", "p_max", "p_min", "p_rms", "u", "u_non_staggered", "u_split_field", "u_max", "u_min", "u_rms", "I", "I_avg"]
-        if not any(self.record.is_set(fields)) and not self.time_rev:
+        if not (isinstance(self.sensor, NotATransducer) or any(self.record.is_set(fields)) or self.time_rev):
             return True
         return False
 

--- a/kwave/kWaveSimulation.py
+++ b/kwave/kWaveSimulation.py
@@ -1311,7 +1311,7 @@ class kWaveSimulation(object):
         """
         # define the output variables and mask indices if using the sensor
         if self.use_sensor:
-            if not self.blank_sensor or isinstance(self.options.save_to_disk, str):
+            if not self.blank_sensor or self.options.save_to_disk:
                 if self.cuboid_corners:
                     # create empty list of sensor indices
                     self.sensor_mask_index = []

--- a/kwave/kmedium.py
+++ b/kwave/kmedium.py
@@ -145,7 +145,7 @@ class kWaveMedium(object):
         assert np.isscalar(self.alpha_power), "medium.alpha_power must be scalar."
 
         # check y is real and within 0 to 3
-        assert np.all(np.isreal(self.alpha_coeff)) and 0 < self.alpha_power < 3, "medium.alpha_power must be a real number between 0 and 3."
+        assert np.all(np.isreal(self.alpha_coeff)) and 0 <= self.alpha_power < 3, "medium.alpha_power must be a real number between 0 and 3."
 
         # display warning if y is close to 1 and the dispersion term has not been set to zero
         if self.alpha_mode != "no_dispersion":

--- a/kwave/utils/matrix.py
+++ b/kwave/utils/matrix.py
@@ -143,7 +143,7 @@ def expand_matrix(
         opts["pad_width"] = exp_coeff
     elif len(matrix.shape) == 2:
         if n_coeff == 2:
-            opts["pad_width"] = [(exp_coeff[0], exp_coeff[0]), (exp_coeff[1], exp_coeff[1])]
+            opts["pad_width"] = [(exp_coeff[0],), (exp_coeff[1],)]
         if n_coeff == 4:
             opts["pad_width"] = [(exp_coeff[0], exp_coeff[1]), (exp_coeff[2], exp_coeff[3])]
     elif len(matrix.shape) == 3:

--- a/kwave/utils/matrix.py
+++ b/kwave/utils/matrix.py
@@ -143,7 +143,7 @@ def expand_matrix(
         opts["pad_width"] = exp_coeff
     elif len(matrix.shape) == 2:
         if n_coeff == 2:
-            opts["pad_width"] = exp_coeff
+            opts["pad_width"] = [(exp_coeff[0], exp_coeff[0]), (exp_coeff[1], exp_coeff[1])]
         if n_coeff == 4:
             opts["pad_width"] = [(exp_coeff[0], exp_coeff[1]), (exp_coeff[2], exp_coeff[3])]
     elif len(matrix.shape) == 3:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -144,7 +144,7 @@ class TestExecutor(unittest.TestCase):
         self.mock_h5py_file.assert_called_once_with("/fake/output.h5", "r")
         mock_file.keys.assert_called_once()
         mock_file.__getitem__.assert_called_once_with("/data")
-        mock_dataset.__getitem__.assert_called_once_with(0)
+        mock_dataset.__getitem__.assert_called_once_with(slice(None))
         mock_dataset.__getitem__.return_value.squeeze.assert_called_once()
         self.assertIn("data", result)
         self.assertTrue(np.all(result["data"] == np.ones((10, 10))))

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,93 @@
+import unittest
+import numpy as np
+import pytest
+from kwave.data import Vector
+from kwave.kgrid import kWaveGrid
+from kwave.kmedium import kWaveMedium
+from kwave.ksource import kSource
+from kwave.ksensor import kSensor
+from kwave.kspaceFirstOrder2D import kspaceFirstOrder2D
+
+from kwave.options.simulation_options import SimulationOptions
+from kwave.options.simulation_execution_options import SimulationExecutionOptions as ExecutionOptions
+from kwave.utils.filters import smooth
+from kwave.utils.mapgen import make_disc
+
+
+class TestUltrasoundSimulationRecording(unittest.TestCase):
+    def setUp(self):
+
+        # Initialize
+        self.source = kSource()
+        self.sensor = kSensor()
+
+        # Simulation settings
+        self.DATA_CAST = "single"  # Use float32 for GPU computations
+        self.binary_name = "kspaceFirstOrder-OMP"
+
+        # create the computational grid
+        self.PML_size = 20  # size of the PML in grid points
+        self.N = Vector([64, 64])  # number of grid points
+        self.d = Vector([0.1e-3, 0.1e-3])  # grid point spacing [m]
+        self.kgrid = kWaveGrid(self.N, self.d)
+
+        # Define the source
+        self.disc_magnitude = 5  # [Pa]
+        self.disc_pos = self.N // 2  # [grid points]
+        self.disc_radius = 8  # [grid points]
+        self.disc = self.disc_magnitude * make_disc(self.N, self.disc_pos, self.disc_radius)
+        self.p0 = smooth(self.disc, restore_max=True)
+        self.source.p0 = self.p0
+
+        # Define the medium properties
+        self.c0_exact = 1540  # [m/s]
+        self.rho0 = 1000  # [kg/m^3]
+        self.alpha_coeff_exact = 0.5  # [dB/(MHz^y cm)]
+        self.medium = kWaveMedium(self.c0_exact, self.rho0, self.alpha_coeff_exact)
+
+        # Define the sensor
+        self.sensor.mask = np.zeros(self.N)
+        self.sensor.mask[0] = 1
+
+        # create the time array
+        self.kgrid.makeTime(self.medium.sound_speed)
+
+
+    def run_simulation(self, record_fields):
+        self.sensor.record = record_fields
+
+        simulation_options = SimulationOptions(
+            pml_inside=False, pml_size=self.PML_size, data_cast=self.DATA_CAST,
+            save_to_disk=True, data_recast=True, smooth_p0=False,
+        )
+        execution_options = ExecutionOptions(is_gpu_simulation=False, binary_name=self.binary_name)
+
+        sensor_data = kspaceFirstOrder2D(
+            kgrid=self.kgrid,
+            medium=self.medium,
+            source=self.source,
+            sensor=self.sensor,
+            simulation_options=simulation_options,
+            execution_options=execution_options,
+        )
+
+        return sensor_data
+
+    def test_record_final_pressure(self):
+        record_fields = ['p_final']
+        sensor_data = self._test_simulation(record_fields=record_fields)
+        for field in record_fields:
+            assert field in sensor_data
+
+    def test_record_pressure(self):
+        record_fields = ['p']
+        sensor_data = self._test_simulation(record_fields=record_fields)
+        for field in record_fields:
+            assert field in sensor_data
+
+    def _test_simulation(self, record_fields):
+        return self.run_simulation(record_fields)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Hey, this PR fixes some small bugs that caused problems:
- Alpha Coefficient can be 0 (kspaceFirstOrder_inputChecking.m:216)
- blank_sensor() should return True, if no fields are set and !time_rev (kspaceFirstOrder_inputChecking.m:482)
- for the 2d case expand_matrix uses exp_coeff as pad_width, but this is equivalent to 
`[(exp_coeff[0], exp_coeff[1]), (exp_coeff[0], exp_coeff[1])]` while it should be `[(exp_coeff[0], exp_coeff[0]), (exp_coeff[1], exp_coeff[1])]`
