### PR TITLE
Update environment variable generation for safer execution

### DIFF
--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -27,7 +27,7 @@ class Executor:
                 raise e
 
     def run_simulation(self, input_filename: str, output_filename: str, options: str):
-        command = [self.execution_options.binary_path, "-i", input_filename, "-o", output_filename, options]
+        command = [str(self.execution_options.binary_path), "-i", input_filename, "-o", output_filename, options]
 
         try:
             with subprocess.Popen(

--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -28,11 +28,7 @@ class Executor:
 
     def run_simulation(self, input_filename: str, output_filename: str, options: str):
         command = (
-            f"{self.execution_options.system_string} "
-            f"{self.execution_options.binary_path} "
-            f"-i {input_filename} "
-            f"-o {output_filename} "
-            f"{options}"
+            f"{self.execution_options.system_string}" f'"{self.execution_options.binary_path}" -i {input_filename} -o {output_filename} {options}'
         )
 
         try:

--- a/kwave/executor.py
+++ b/kwave/executor.py
@@ -27,12 +27,12 @@ class Executor:
                 raise e
 
     def run_simulation(self, input_filename: str, output_filename: str, options: str):
-        command = (
-            f"{self.execution_options.system_string}" f'"{self.execution_options.binary_path}" -i {input_filename} -o {output_filename} {options}'
-        )
+        command = [self.execution_options.binary_path, "-i", input_filename, "-o", output_filename, options]
 
         try:
-            with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True) as proc:
+            with subprocess.Popen(
+                command, env=self.execution_options.env_vars, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            ) as proc:
                 stdout, stderr = "", ""
                 if self.execution_options.show_sim_log:
                     # Stream stdout in real-time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = ["pytest",
 example = ["gdown==5.2.0"]
 docs = [ "sphinx-mdinclude==0.6.2",
     "sphinx-copybutton==0.5.2",
-    "sphinx-tabs==3.4.5",
+    "sphinx-tabs==3.4.7",
     "sphinx-toolbox==3.8.0",
     "furo==2024.8.6"]
 dev = ["pre-commit==4.0.1"]

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -99,7 +99,7 @@ class TestExecutor(unittest.TestCase):
             sensor_data = executor.run_simulation("input.h5", "output.h5", "options")
 
         normalized_path = os.path.normpath(self.execution_options.binary_path)
-        expected_command = f"{self.execution_options.system_string} " f'"{normalized_path}"' f"-i input.h5 " f"-o output.h5 " f"options"
+        expected_command = f"{self.execution_options.system_string}" f'"{normalized_path}"' f"-i input.h5 " f"-o output.h5 " f"options"
 
         self.mock_popen.assert_called_once_with(expected_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
         self.mock_proc.communicate.assert_called_once()

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -99,7 +99,7 @@ class TestExecutor(unittest.TestCase):
             sensor_data = executor.run_simulation("input.h5", "output.h5", "options")
 
         normalized_path = os.path.normpath(self.execution_options.binary_path)
-        expected_command = f"{self.execution_options.system_string}" f'"{normalized_path}"' f"-i input.h5 " f"-o output.h5 " f"options"
+        expected_command = f"{self.execution_options.system_string}" f'"{normalized_path}"-i input.h5 ' f"-o output.h5 " f"options"
 
         self.mock_popen.assert_called_once_with(expected_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
         self.mock_proc.communicate.assert_called_once()

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -99,7 +99,7 @@ class TestExecutor(unittest.TestCase):
             sensor_data = executor.run_simulation("input.h5", "output.h5", "options")
 
         normalized_path = os.path.normpath(self.execution_options.binary_path)
-        expected_command = f"{self.execution_options.system_string}" f'"{normalized_path}"-i input.h5 ' f"-o output.h5 " f"options"
+        expected_command = f"{self.execution_options.system_string}" f'"{normalized_path}" -i input.h5 ' f"-o output.h5 " f"options"
 
         self.mock_popen.assert_called_once_with(expected_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
         self.mock_proc.communicate.assert_called_once()

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -99,9 +99,11 @@ class TestExecutor(unittest.TestCase):
             sensor_data = executor.run_simulation("input.h5", "output.h5", "options")
 
         normalized_path = os.path.normpath(self.execution_options.binary_path)
-        expected_command = f"{self.execution_options.system_string}" f'"{normalized_path}" -i input.h5 ' f"-o output.h5 " f"options"
+        expected_command = [normalized_path, "-i", "input.h5", "-o", "output.h5", "options"]
 
-        self.mock_popen.assert_called_once_with(expected_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
+        self.mock_popen.assert_called_once_with(
+            expected_command, env=self.execution_options.env_vars, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
         self.mock_proc.communicate.assert_called_once()
         self.assertEqual(sensor_data, dotdict())
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -99,7 +99,7 @@ class TestExecutor(unittest.TestCase):
             sensor_data = executor.run_simulation("input.h5", "output.h5", "options")
 
         normalized_path = os.path.normpath(self.execution_options.binary_path)
-        expected_command = f"{self.execution_options.system_string} " f"{normalized_path} " f"-i input.h5 " f"-o output.h5 " f"options"
+        expected_command = f"{self.execution_options.system_string} " f'"{normalized_path}"' f"-i input.h5 " f"-o output.h5 " f"options"
 
         self.mock_popen.assert_called_once_with(expected_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
         self.mock_proc.communicate.assert_called_once()

--- a/tests/test_simulation_execution_options.py
+++ b/tests/test_simulation_execution_options.py
@@ -12,12 +12,13 @@ class TestSimulationExecutionOptions(unittest.TestCase):
         self.sensor.record_start_index = 10
 
     def test_default_initialization(self):
-        options = SimulationExecutionOptions()
-        self.assertFalse(options.is_gpu_simulation)
-        self.assertEqual(options.binary_name, "kspaceFirstOrder-OMP")
-        self.assertTrue(options.delete_data)
-        self.assertEqual(options.num_threads, None)  # TODO: confusing logic here
-        self.assertEqual(options.verbose_level, 0)
+        with patch("kwave.options.simulation_execution_options.PLATFORM", "linux"):
+            options = SimulationExecutionOptions()
+            self.assertFalse(options.is_gpu_simulation)
+            self.assertEqual(options.binary_name, "kspaceFirstOrder-OMP")
+            self.assertTrue(options.delete_data)
+            self.assertEqual(options.num_threads, None)  # TODO: confusing logic here
+            self.assertEqual(options.verbose_level, 0)
 
     def test_gpu_simulation_initialization(self):
         options = SimulationExecutionOptions(is_gpu_simulation=True)

--- a/tests/test_simulation_execution_options.py
+++ b/tests/test_simulation_execution_options.py
@@ -1,0 +1,69 @@
+import unittest
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.ksensor import kSensor
+from unittest.mock import patch
+
+
+class TestSimulationExecutionOptions(unittest.TestCase):
+    def setUp(self):
+        # Set up a default kSensor object for testing
+        self.sensor = kSensor()
+        self.sensor.record = ["p", "u"]
+        self.sensor.record_start_index = 10
+
+    def test_default_initialization(self):
+        options = SimulationExecutionOptions()
+        self.assertFalse(options.is_gpu_simulation)
+        self.assertEqual(options.binary_name, "kspaceFirstOrder-OMP")
+        self.assertTrue(options.delete_data)
+        self.assertEqual(options.num_threads, None)  # TODO: confusing logic here
+        self.assertEqual(options.verbose_level, 0)
+
+    def test_gpu_simulation_initialization(self):
+        options = SimulationExecutionOptions(is_gpu_simulation=True)
+        self.assertTrue(options.is_gpu_simulation)
+        self.assertEqual(options.binary_name, "kspaceFirstOrder-CUDA")
+
+    def test_binary_name_extension_on_windows(self):
+        with patch("kwave.options.simulation_execution_options.PLATFORM", "windows"):
+            options = SimulationExecutionOptions()
+            self.assertTrue(options.binary_name.endswith(".exe"))
+
+    def test_get_options_string(self):
+        options = SimulationExecutionOptions()
+        options_string = options.get_options_string(self.sensor)
+        self.assertIn("--p_raw", options_string)
+        self.assertIn("--u_raw", options_string)
+        self.assertIn("-s 10", options_string)
+
+    def test_env_vars_linux(self):
+        with patch("kwave.options.simulation_execution_options.PLATFORM", "linux"):
+            options = SimulationExecutionOptions()
+            env_vars = options.env_vars
+            self.assertIn("OMP_PLACES", env_vars)
+            self.assertEqual(env_vars["OMP_PLACES"], "cores")
+            self.assertIn("OMP_PROC_BIND", env_vars)
+            self.assertEqual(env_vars["OMP_PROC_BIND"], "SPREAD")
+
+    def test_thread_binding_linux(self):
+        with patch("kwave.options.simulation_execution_options.PLATFORM", "linux"):
+            options = SimulationExecutionOptions(thread_binding=True)
+            env_vars = options.env_vars
+            self.assertEqual(env_vars["OMP_PROC_BIND"], "SPREAD")
+
+    def test_thread_binding_darwin(self):
+        with patch("kwave.options.simulation_execution_options.PLATFORM", "darwin"):
+            options = SimulationExecutionOptions(thread_binding=True)
+            with self.assertRaises(ValueError, msg="Thread binding is not supported in MacOS."):
+                _ = options.env_vars
+
+    def test_env_vars_darwin(self):
+        with patch("kwave.options.simulation_execution_options.PLATFORM", "darwin"):
+            options = SimulationExecutionOptions()
+            env_vars = options.env_vars
+            self.assertNotIn("OMP_PLACES", env_vars)
+            self.assertNotIn("OMP_PROC_BIND", env_vars)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_simulation_execution_options.py
+++ b/tests/test_simulation_execution_options.py
@@ -21,9 +21,10 @@ class TestSimulationExecutionOptions(unittest.TestCase):
             self.assertEqual(options.verbose_level, 0)
 
     def test_gpu_simulation_initialization(self):
-        options = SimulationExecutionOptions(is_gpu_simulation=True)
-        self.assertTrue(options.is_gpu_simulation)
-        self.assertEqual(options.binary_name, "kspaceFirstOrder-CUDA")
+        with patch("kwave.options.simulation_execution_options.PLATFORM", "linux"):
+            options = SimulationExecutionOptions(is_gpu_simulation=True)
+            self.assertTrue(options.is_gpu_simulation)
+            self.assertEqual(options.binary_name, "kspaceFirstOrder-CUDA")
 
     def test_binary_name_extension_on_windows(self):
         with patch("kwave.options.simulation_execution_options.PLATFORM", "windows"):


### PR DESCRIPTION
As mentioned in #484, execution safety and reliability could be improved. We merged a patch fix in #489, but this updated logic adds the required environment variables separately to the subprocess and removes the need for `shell=True`

Closes #491 