### PR TITLE
Avoid setting p0 to None during assignment

### DIFF
--- a/kwave/ksource.py
+++ b/kwave/ksource.py
@@ -58,7 +58,6 @@ class kSource(object):
 
     @p0.setter
     def p0(self, val):
-        print(val.sum())
         # check size and contents
         if len(val) == 0:
             # if the initial pressure is empty, remove field

--- a/kwave/ksource.py
+++ b/kwave/ksource.py
@@ -58,8 +58,9 @@ class kSource(object):
 
     @p0.setter
     def p0(self, val):
+        print(val.sum())
         # check size and contents
-        if len(val) == 0 or np.sum(val != 0) == 0:
+        if len(val) == 0:
             # if the initial pressure is empty, remove field
             self._p0 = None
         else:

--- a/tests/test_ksource.py
+++ b/tests/test_ksource.py
@@ -1,0 +1,42 @@
+import unittest
+import numpy as np
+from kwave.ksource import kSource
+
+
+class TestKSource(unittest.TestCase):
+    def setUp(self):
+        self.source = kSource()
+
+    def test_p0_setter_empty_array(self):
+        """Test that p0 is set to None when given an empty array"""
+        self.source.p0 = np.array([])
+        self.assertIsNone(self.source.p0)
+
+    def test_p0_setter_non_empty_array(self):
+        """Test that p0 is set correctly for non-empty array"""
+        test_array = np.array([1.0, 2.0, 3.0])
+        self.source.p0 = test_array
+        np.testing.assert_array_equal(self.source.p0, test_array)
+
+    def test_p0_setter_zero_array(self):
+        """Test that p0 is set correctly for array of zeros (should not be set to None)"""
+        test_array = np.zeros(5)
+        self.source.p0 = test_array
+        np.testing.assert_array_equal(self.source.p0, test_array)
+
+    def test_is_p0_empty(self):
+        """Test the is_p0_empty method"""
+        # Test with None
+        self.assertTrue(self.source.is_p0_empty())
+
+        # Test with empty array
+        self.source.p0 = np.array([])
+        self.assertTrue(self.source.is_p0_empty())
+
+        # Test with non-empty array
+        self.source.p0 = np.array([1.0, 2.0])
+        self.assertFalse(self.source.is_p0_empty())
+
+        # Test with zero array
+        self.source.p0 = np.zeros(5)
+        self.assertTrue(self.source.is_p0_empty())


### PR DESCRIPTION
Fixed #468 

Not sure why we even have a logic to assign `p0` to `None`. Could not find any reason. 