### PR TITLE
Refactor sharpness filters and improve single_sided_correction

### DIFF
--- a/kwave/utils/filters.py
+++ b/kwave/utils/filters.py
@@ -186,7 +186,7 @@ def extract_amp_phase(
     data = win * data
 
     # compute amplitude and phase spectra
-    f, func_as, func_ps = spect(data, Fs, fft_len=fft_padding * data.shape[dim], dim=dim)
+    f, func_as, func_ps = spect(data, fs, fft_len=fft_padding * data.shape[dim], dim=dim)
 
     # correct for coherent gain
     func_as = func_as / coherent_gain

--- a/kwave/utils/filters.py
+++ b/kwave/utils/filters.py
@@ -4,13 +4,13 @@ from typing import List, Optional, Tuple, Union
 import numpy as np
 import scipy
 from scipy.fftpack import fft, fftshift, ifft, ifftshift
-from scipy.signal import convolve, lfilter
+from scipy.signal import lfilter
 
 from ..kgrid import kWaveGrid
 from ..kmedium import kWaveMedium
 from .checks import is_number
 from .data import scale_SI
-from .math import find_closest, gaussian, next_pow2, norm_var, sinc
+from .math import find_closest, gaussian, next_pow2, sinc
 from .matrix import num_dim, num_dim2
 from .signals import get_win
 
@@ -27,35 +27,25 @@ def single_sided_correction(func_fft: np.ndarray, fft_len: int, dim: int) -> np.
         dim: The number of dimensions of `func_fft`.
 
     Returns:
-        The corrected FFT of the function.
+        None, modifies the input array in place to have the corrected FFT of the function.
     """
-    if fft_len % 2:
-        # odd FFT length switch dim case
-        if dim == 0:
-            func_fft[1:, :] = func_fft[1:, :] * 2
-        elif dim == 1:
-            func_fft[:, 1:] = func_fft[:, 1:] * 2
-        elif dim == 2:
-            func_fft[:, :, 1:] = func_fft[:, :, 1:] * 2
-        elif dim == 3:
-            func_fft[:, :, :, 1:] = func_fft[:, :, :, 1:] * 2
-    else:
-        # even FFT length
-        if dim == 0:
-            func_fft[1:-1] = func_fft[1:-1] * 2
-        elif dim == 1:
-            func_fft[:, 1:-1] = func_fft[:, 1:-1] * 2
-        elif dim == 2:
-            func_fft[:, :, 1:-1] = func_fft[:, :, 1:-1] * 2
-        elif dim == 3:
-            func_fft[:, :, :, 1:-1] = func_fft[:, :, :, 1:-1] * 2
+    # Create a slice object for each dimension
+    slices = [slice(None)] * func_fft.ndim
 
-    return func_fft
+    if fft_len % 2:  # odd FFT length
+        # Set slice for the specified dimension to select all elements except the first
+        slices[dim] = slice(1, None)
+    else:  # even FFT length
+        # Set slice for the specified dimension to select all elements except first and last
+        slices[dim] = slice(1, -1)
+
+    # Apply the slicing and multiply by 2
+    func_fft[tuple(slices)] *= 2
 
 
 def spect(
     func: np.ndarray,
-    Fs: float,
+    fs: float,
     dim: Optional[Union[int, str]] = "auto",
     fft_len: Optional[int] = 0,
     power_two: Optional[bool] = False,
@@ -67,7 +57,7 @@ def spect(
 
     Args:
         func: The signal to analyse.
-        Fs: The sampling frequency in Hz.
+        fs: The sampling frequency in Hz.
         dim: The dimension over which the spectrum is calculated. Defaults to 'auto'.
         fft_len: The length of the FFT. If the set length is smaller than the signal length, the default value is used
                  instead (default = signal length).
@@ -138,10 +128,10 @@ def spect(
     slicing[dim] = slice(0, num_unique_pts)
     func_fft = func_fft[tuple(slicing)]
 
-    func_fft = single_sided_correction(func_fft, fft_len, dim)
+    single_sided_correction(func_fft, fft_len, dim)
 
     # create the frequency axis variable
-    f = np.arange(0, num_unique_pts) * Fs / fft_len
+    f = np.arange(0, num_unique_pts) * fs / fft_len
 
     # calculate the amplitude spectrum
     func_as = np.abs(func_fft)
@@ -157,7 +147,7 @@ def spect(
 
 
 def extract_amp_phase(
-    data: np.ndarray, Fs: float, source_freq: float, dim: Tuple[str, int] = "auto", fft_padding: int = 3, window: str = "Hanning"
+    data: np.ndarray, fs: float, source_freq: float, dim: Tuple[str, int] = "auto", fft_padding: int = 3, window: str = "Hanning"
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Extract the amplitude and phase information at a specified frequency from a vector or matrix of time series data.
@@ -168,7 +158,7 @@ def extract_amp_phase(
 
     Args:
         data: Matrix of time signals [s]
-        Fs: Sampling frequency [Hz]
+        fs: Sampling frequency [Hz]
         source_freq: Frequency at which the amplitude and phase should be extracted [Hz]
         dim: The time dimension of the input data. If 'auto', the highest non-singleton dimension is used.
         fft_padding: The amount of zero padding to apply to the FFT.
@@ -196,7 +186,7 @@ def extract_amp_phase(
     data = win * data
 
     # compute amplitude and phase spectra
-    f, func_as, func_ps = spect(data, Fs, fft_len=fft_padding * data.shape[dim], dim=dim)
+    f, func_as, func_ps = spect(data, fs, fft_len=fft_padding * data.shape[dim], dim=dim)
 
     # correct for coherent gain
     func_as = func_as / coherent_gain
@@ -225,99 +215,6 @@ def extract_amp_phase(
         raise ValueError("dim must be 0, 1, 2, or 3")
 
     return amp.squeeze(), phase.squeeze(), f[f_index]
-
-
-def brenner_sharpness(im):
-    num_dim = im.ndim
-    if num_dim == 2:
-        # compute metric
-        bren_x = (im[:-2, :] - im[2:, :]) ** 2
-        bren_y = (im[:, :-2] - im[:, 2:]) ** 2
-        s = np.sum(bren_x) + np.sum(bren_y)
-    elif num_dim == 3:
-        # compute metric
-        bren_x = (im[:-2, :, :] - im[2:, :, :]) ** 2
-        bren_y = (im[:, :-2, :] - im[:, 2:, :]) ** 2
-        bren_z = (im[:, :, :-2] - im[:, :, 2:]) ** 2
-        s = np.sum(bren_x) + np.sum(bren_y) + np.sum(bren_z)
-    return s
-
-
-def tenenbaum_sharpness(im):
-    num_dim = im.ndim
-    if num_dim == 2:
-        # define the 2D sobel gradient operator
-        sobel = np.array([[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]])
-
-        # compute metric
-        s = (convolve(sobel, im) ** 2 + convolve(sobel.T, im) ** 2).sum()
-    elif num_dim == 3:
-        # define the 3D sobel gradient operator
-        sobel3D = np.zeros((3, 3, 3))
-        sobel3D[:, :, 0] = np.array([[1, 2, 1], [2, 4, 2], [1, 2, 1]])
-        sobel3D[:, :, 2] = -sobel3D[:, :, 0]
-
-        # compute metric
-        s = (
-            convolve(im, sobel3D) ** 2
-            + convolve(im, np.transpose(sobel3D, (2, 0, 1))) ** 2
-            + convolve(im, np.transpose(sobel3D, (1, 2, 0))) ** 2
-        ).sum()
-    return s
-
-    # TODO: get this passing the tests
-    # NOTE: Walter thinks this is the proper way to do this, but it doesn't match the MATLAB version
-    # num_dim = im.ndim
-    # if num_dim == 2:
-    #     # compute metric
-    #     sx = sobel(im, axis=0, mode='constant')
-    #     sy = sobel(im, axis=1, mode='constant')
-    #     s = (sx ** 2) + (sy ** 2)
-    #     s = np.sum(s)
-    #
-    # elif num_dim == 3:
-    #     # compute metric
-    #     sx = sobel(im, axis=0, mode='constant')
-    #     sy = sobel(im, axis=1, mode='constant')
-    #     sz = sobel(im, axis=2, mode='constant')
-    #     s = (sx ** 2) + (sy ** 2) + (sz ** 2)
-    #     s = np.sum(s)
-    # else:
-    #     raise ValueError("Invalid number of dimensions in im")
-
-
-def sharpness(im: np.ndarray, mode: Optional[str] = "Brenner") -> float:
-    """
-    Returns a scalar metric related to the sharpness of a 2D or 3D image matrix.
-
-    Args:
-        im: The image matrix.
-        metric: The metric to use. Defaults to "Brenner".
-
-    Returns:
-        A scalar sharpness metric.
-
-    Raises:
-        AssertionError: If `im` is not a NumPy array.
-
-    References:
-        B. E. Treeby, T. K. Varslot, E. Z. Zhang, J. G. Laufer, and P. C. Beard, "Automatic sound speed selection in
-        photoacoustic image reconstruction using an autofocus approach," J. Biomed. Opt., vol. 16, no. 9, p. 090501, 2011.
-
-    """
-
-    assert isinstance(im, np.ndarray), "Argument im must be of type numpy array"
-
-    if mode == "Brenner":
-        metric = brenner_sharpness(im)
-    elif mode == "Tenenbaum":
-        metric = tenenbaum_sharpness(im)
-    elif mode == "NormVariance":
-        metric = norm_var(im)
-    else:
-        raise ValueError("Unrecognized sharpness metric passed. Valid values are ['Brenner', 'Tanenbaum', 'NormVariance']")
-
-    return metric
 
 
 def fwhm(f, x):
@@ -357,7 +254,7 @@ def fwhm(f, x):
 
 
 def gaussian_filter(
-    signal: Union[np.ndarray, List[float]], Fs: float, frequency: float, bandwidth: float
+    signal: Union[np.ndarray, List[float]], fs: float, frequency: float, bandwidth: float
 ) -> Union[np.ndarray, List[float]]:
     """
     Applies a frequency domain Gaussian filter with the
@@ -367,7 +264,7 @@ def gaussian_filter(
 
     Args:
         signal:         Signal to filter [channel, samples]
-        Fs:             Sampling frequency [Hz]
+        fs:             Sampling frequency [Hz]
         frequency:      Center frequency of filter [Hz]
         bandwidth:      Bandwidth of filter in percentage
 
@@ -378,9 +275,9 @@ def gaussian_filter(
 
     N = signal.shape[-1]
     if N % 2 == 0:
-        f = np.arange(-N / 2, N / 2) * Fs / N
+        f = np.arange(-N / 2, N / 2) * fs / N
     else:
-        f = np.arange(-(N - 1) / 2, (N - 1) / 2 + 1) * Fs / N
+        f = np.arange(-(N - 1) / 2, (N - 1) / 2 + 1) * fs / N
 
     mean = frequency
     variance = (bandwidth / 100 * frequency / (2 * np.sqrt(2 * np.log(2)))) ** 2
@@ -472,7 +369,7 @@ def filter_time_series(
     assert not isinstance(kgrid.t_array, str) or kgrid.t_array != "auto", "kgrid.t_array must be explicitly defined."
 
     # compute the sampling frequency
-    Fs = 1 / kgrid.dt
+    fs = 1 / kgrid.dt
 
     # extract the minimum sound speed
     if medium.sound_speed is not None:
@@ -506,7 +403,7 @@ def filter_time_series(
     if ppw != 0:
         filtered_signal = apply_filter(
             signal,
-            Fs,
+            fs,
             float(filter_cutoff_f),
             "LowPass",
             zero_phase=zerophase,
@@ -548,7 +445,7 @@ def filter_time_series(
 
 def apply_filter(
     signal: np.ndarray,
-    Fs: float,
+    fs: float,
     cutoff_f: float,
     filter_type: str,
     zero_phase: Optional[bool] = False,
@@ -561,7 +458,7 @@ def apply_filter(
 
     Args:
         signal: The input signal.
-        Fs: The sampling frequency of the signal.
+        fs: The sampling frequency of the signal.
         cutoff_f: The cut-off frequency of the filter.
         filter_type: The type of filter to apply, either 'HighPass', 'LowPass' or 'BandPass'.
         zero_phase: Whether to apply a zero-phase filter. Defaults to False.
@@ -580,13 +477,13 @@ def apply_filter(
 
         # apply the low pass filter
         func_filt_lp = apply_filter(
-            signal, Fs, cutoff_f[1], "LowPass", stop_band_atten=stop_band_atten, transition_width=transition_width, zero_phase=zero_phase
+            signal, fs, cutoff_f[1], "LowPass", stop_band_atten=stop_band_atten, transition_width=transition_width, zero_phase=zero_phase
         )
 
         # apply the high pass filter
         filtered_signal = apply_filter(
             func_filt_lp,
-            Fs,
+            fs,
             cutoff_f[0],
             "HighPass",
             stop_band_atten=stop_band_atten,
@@ -600,7 +497,7 @@ def apply_filter(
             high_pass = False
         elif filter_type == "HighPass":
             high_pass = True
-            cutoff_f = Fs / 2 - cutoff_f
+            cutoff_f = fs / 2 - cutoff_f
         else:
             raise ValueError(f'Unknown filter type {filter_type}. Options are "LowPass, HighPass, BandPass"')
 
@@ -618,7 +515,7 @@ def apply_filter(
         N = int(N)
 
         # construct impulse response of ideal bandpass filter h(n), a sinc function
-        fc = cutoff_f / Fs  # normalised cut-off
+        fc = cutoff_f / fs  # normalised cut-off
         n = np.arange(-N / 2, N / 2)
         h = 2 * fc * sinc(2 * np.pi * fc * n)
 

--- a/kwave/utils/math.py
+++ b/kwave/utils/math.py
@@ -357,22 +357,6 @@ def sinc(x: Union[int, float, np.ndarray]) -> Union[int, float, np.ndarray]:
     return np.sinc(x / np.pi)
 
 
-def norm_var(im: np.ndarray) -> float:
-    """
-    Calculates the normalized variance of an array of values.
-
-    Args:
-        im: The input array.
-
-    Returns:
-        The normalized variance of im.
-
-    """
-    mu = np.mean(im)
-    s = np.sum((im - mu) ** 2) / mu
-    return s
-
-
 def gaussian(
     x: Union[int, float, np.ndarray],
     magnitude: Optional[Union[int, float]] = None,

--- a/kwave/utils/sharpness_filters.py
+++ b/kwave/utils/sharpness_filters.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import numpy as np
-from scipy.ndimage import convolve
+from scipy.signal import convolve
 
 
 def brenner_sharpness(im):

--- a/kwave/utils/sharpness_filters.py
+++ b/kwave/utils/sharpness_filters.py
@@ -1,0 +1,126 @@
+from typing import Optional
+
+import numpy as np
+from scipy.ndimage import convolve
+
+
+def brenner_sharpness(im):
+    """Calculate Brenner's measure of focus/sharpness.
+
+    Computes squared differences between pixels that are 2 units apart
+    along each dimension, then sums all differences.
+
+    Args:
+        im: Input image/volume array
+
+    Returns:
+        Single scalar value representing the sharpness measure
+    """
+    s = 0
+    for dim in range(im.ndim):
+        # Create slices for the current dimension
+        slice1 = [slice(None)] * im.ndim
+        slice2 = [slice(None)] * im.ndim
+
+        # Set the slices for the dimension we're processing
+        slice1[dim] = slice(None, -2)
+        slice2[dim] = slice(2, None)
+
+        # Calculate squared difference for this dimension and add to total
+        brenner_dim = (im[tuple(slice1)] - im[tuple(slice2)]) ** 2
+        s += np.sum(brenner_dim)
+
+    return s
+
+
+def tenenbaum_sharpness(im: np.ndarray) -> float | None:
+    num_dim = im.ndim
+    if num_dim == 2:
+        # define the 2D sobel gradient operator
+        sobel = np.array([[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]])
+
+        # compute metric
+        s = (convolve(sobel, im) ** 2 + convolve(sobel.T, im) ** 2).sum()
+    elif num_dim == 3:
+        # define the 3D sobel gradient operator
+        sobel3D = np.zeros((3, 3, 3))
+        sobel3D[:, :, 0] = np.array([[1, 2, 1], [2, 4, 2], [1, 2, 1]])
+        sobel3D[:, :, 2] = -sobel3D[:, :, 0]
+
+        # compute metric
+        s = (
+            convolve(im, sobel3D) ** 2
+            + convolve(im, np.transpose(sobel3D, (2, 0, 1))) ** 2
+            + convolve(im, np.transpose(sobel3D, (1, 2, 0))) ** 2
+        ).sum()
+    return s
+
+    # TODO: get this passing the tests
+    # NOTE: Walter thinks this is the proper way to do this, but it doesn't match the MATLAB version
+    # num_dim = im.ndim
+    # if num_dim == 2:
+    #     # compute metric
+    #     sx = sobel(im, axis=0, mode='constant')
+    #     sy = sobel(im, axis=1, mode='constant')
+    #     s = (sx ** 2) + (sy ** 2)
+    #     s = np.sum(s)
+    #
+    # elif num_dim == 3:
+    #     # compute metric
+    #     sx = sobel(im, axis=0, mode='constant')
+    #     sy = sobel(im, axis=1, mode='constant')
+    #     sz = sobel(im, axis=2, mode='constant')
+    #     s = (sx ** 2) + (sy ** 2) + (sz ** 2)
+    #     s = np.sum(s)
+    # else:
+    #     raise ValueError("Invalid number of dimensions in im")
+
+
+def norm_var(im: np.ndarray) -> float:
+    """
+    Calculates the normalized variance of an array of values.
+
+    Args:
+        im: The input array.
+
+    Returns:
+        The normalized variance of im.
+
+    """
+    mu = np.mean(im)
+    s = np.sum((im - mu) ** 2) / mu
+    return s
+
+
+def sharpness(im: np.ndarray, mode: Optional[str] = "Brenner") -> float:
+    """
+    Returns a scalar metric related to the sharpness of a 2D or 3D image matrix.
+
+    Args:
+        im: The image matrix.
+        metric: The metric to use. Defaults to "Brenner".
+
+    Returns:
+        A scalar sharpness metric.
+
+    Raises:
+        AssertionError: If `im` is not a NumPy array.
+
+    References:
+        B. E. Treeby, T. K. Varslot, E. Z. Zhang, J. G. Laufer, and P. C. Beard, "Automatic sound speed selection in
+        photoacoustic image reconstruction using an autofocus approach," J. Biomed. Opt., vol. 16, no. 9, p. 090501, 2011.
+
+    """
+
+    assert isinstance(im, np.ndarray), "Argument im must be of type numpy array"
+
+    if mode == "Brenner":
+        metric = brenner_sharpness(im)
+    elif mode == "Tenenbaum":
+        metric = tenenbaum_sharpness(im)
+    elif mode == "NormVariance":
+        metric = norm_var(im)
+    else:
+        raise ValueError("Unrecognized sharpness metric passed. " "Valid values are ['Brenner', 'Tanenbaum', 'NormVariance']")
+
+    return metric

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    ignore:The interactive_bk attribute was deprecated.*:matplotlib._api.deprecation.MatplotlibDeprecationWarning
+    # Add any other warning filters you might need below

--- a/tests/matlab_test_data_collectors/python_testers/sharpness_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/sharpness_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 
-from kwave.utils.filters import sharpness
+from kwave.utils import sharpness_filters
 from tests.matlab_test_data_collectors.python_testers.utils.record_reader import TestRecordReader
 
 
@@ -12,7 +12,7 @@ def test_tennenbaum2d():
     reader = TestRecordReader(test_record_path)
     img = reader.expected_value_of("img2")
 
-    out = sharpness(img, "Tenenbaum")
+    out = sharpness_filters(img, "Tenenbaum")
 
     out_prime = reader.expected_value_of("out2")
     assert np.allclose(out, out_prime), "Tenenbaum sharpness did not match expected sharpness in 2D"
@@ -23,7 +23,7 @@ def test_tennenbaum3d():
     reader = TestRecordReader(test_record_path)
 
     img = reader.expected_value_of("img3")
-    out = sharpness(img, "Tenenbaum")
+    out = sharpness_filters(img, "Tenenbaum")
     out_prime = reader.expected_value_of("out3")
     assert np.allclose(out, out_prime), "Tenenbaum sharpness did not match expected sharpness in 3D"
 
@@ -32,7 +32,7 @@ def test_brenner2d():
     test_record_path = os.path.join(Path(__file__).parent, Path("collectedValues/brenner.mat"))
     reader = TestRecordReader(test_record_path)
     img = reader.expected_value_of("img2")
-    out = sharpness(img, "Brenner")
+    out = sharpness_filters(img, "Brenner")
 
     out_prime = reader.expected_value_of("out2")
     assert np.allclose(out, out_prime), "Brenner sharpness did not match expected sharpness in 2D"
@@ -43,7 +43,7 @@ def test_brenner3d():
     reader = TestRecordReader(test_record_path)
 
     img = reader.expected_value_of("img3")
-    out = sharpness(img, "Brenner")
+    out = sharpness_filters(img, "Brenner")
     out_prime = reader.expected_value_of("out3")
     assert np.allclose(out, out_prime), "Brenner sharpness did not match expected sharpness in 3D"
 
@@ -53,12 +53,12 @@ def test_normvar():
     reader = TestRecordReader(test_record_path)
     img = reader.expected_value_of("img2")
 
-    out = sharpness(img, "NormVariance")
+    out = sharpness_filters(img, "NormVariance")
 
     out_prime = reader.expected_value_of("out2")
     assert np.allclose(out, out_prime), "NormVariance sharpness did not match expected sharpness in 2D"
 
     img = reader.expected_value_of("img3")
-    out = sharpness(img, "NormVariance")
+    out = sharpness_filters(img, "NormVariance")
     out_prime = reader.expected_value_of("out3")
     assert np.allclose(out, out_prime), "NormVariance sharpness did not match expected sharpness in 3D"

--- a/tests/matlab_test_data_collectors/python_testers/sharpness_test.py
+++ b/tests/matlab_test_data_collectors/python_testers/sharpness_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 
-from kwave.utils import sharpness_filters
+from kwave.utils.sharpness_filters import sharpness
 from tests.matlab_test_data_collectors.python_testers.utils.record_reader import TestRecordReader
 
 
@@ -12,7 +12,7 @@ def test_tennenbaum2d():
     reader = TestRecordReader(test_record_path)
     img = reader.expected_value_of("img2")
 
-    out = sharpness_filters(img, "Tenenbaum")
+    out = sharpness(img, "Tenenbaum")
 
     out_prime = reader.expected_value_of("out2")
     assert np.allclose(out, out_prime), "Tenenbaum sharpness did not match expected sharpness in 2D"
@@ -23,7 +23,7 @@ def test_tennenbaum3d():
     reader = TestRecordReader(test_record_path)
 
     img = reader.expected_value_of("img3")
-    out = sharpness_filters(img, "Tenenbaum")
+    out = sharpness(img, "Tenenbaum")
     out_prime = reader.expected_value_of("out3")
     assert np.allclose(out, out_prime), "Tenenbaum sharpness did not match expected sharpness in 3D"
 
@@ -32,7 +32,7 @@ def test_brenner2d():
     test_record_path = os.path.join(Path(__file__).parent, Path("collectedValues/brenner.mat"))
     reader = TestRecordReader(test_record_path)
     img = reader.expected_value_of("img2")
-    out = sharpness_filters(img, "Brenner")
+    out = sharpness(img, "Brenner")
 
     out_prime = reader.expected_value_of("out2")
     assert np.allclose(out, out_prime), "Brenner sharpness did not match expected sharpness in 2D"
@@ -43,7 +43,7 @@ def test_brenner3d():
     reader = TestRecordReader(test_record_path)
 
     img = reader.expected_value_of("img3")
-    out = sharpness_filters(img, "Brenner")
+    out = sharpness(img, "Brenner")
     out_prime = reader.expected_value_of("out3")
     assert np.allclose(out, out_prime), "Brenner sharpness did not match expected sharpness in 3D"
 
@@ -53,12 +53,12 @@ def test_normvar():
     reader = TestRecordReader(test_record_path)
     img = reader.expected_value_of("img2")
 
-    out = sharpness_filters(img, "NormVariance")
+    out = sharpness(img, "NormVariance")
 
     out_prime = reader.expected_value_of("out2")
     assert np.allclose(out, out_prime), "NormVariance sharpness did not match expected sharpness in 2D"
 
     img = reader.expected_value_of("img3")
-    out = sharpness_filters(img, "NormVariance")
+    out = sharpness(img, "NormVariance")
     out_prime = reader.expected_value_of("out3")
     assert np.allclose(out, out_prime), "NormVariance sharpness did not match expected sharpness in 3D"

--- a/tests/test_create_pixel_dim.py
+++ b/tests/test_create_pixel_dim.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 
 from kwave.utils.mapgen import create_pixel_dim
 

--- a/tests/test_filterutils.py
+++ b/tests/test_filterutils.py
@@ -3,7 +3,7 @@ from math import pi
 import numpy as np
 
 from kwave.reconstruction.beamform import envelope_detection
-from kwave.utils.filters import fwhm
+from kwave.utils.filters import fwhm, single_sided_correction
 
 
 def test_envelope_detection():
@@ -31,3 +31,138 @@ def test_fwhm():
 
     assert np.isclose(val, 6.691, rtol=1e-3)
     assert np.isclose((positions[1] - positions[0]) / 2 + positions[0], 10, rtol=1e-3)
+
+
+class TestSingleSidedCorrection:
+    """Tests for the single_sided_correction function."""
+
+    def test_odd_fft_length_dim0(self):
+        """Test single_sided_correction with odd FFT length and dim=0."""
+        func_fft = np.ones((5, 3))
+        fft_len = 5
+        dim = 0
+        single_sided_correction(func_fft, fft_len, dim)
+
+        # Check that first row is unchanged (DC component)
+        assert np.array_equal(func_fft[0, :], np.ones(3))
+        # Check that all other rows are multiplied by 2
+        assert np.array_equal(func_fft[1:, :], 2 * np.ones((4, 3)))
+
+    def test_odd_fft_length_dim1(self):
+        """Test single_sided_correction with odd FFT length and dim=1."""
+        func_fft = np.ones((3, 5))
+        fft_len = 5
+        dim = 1
+        single_sided_correction(func_fft, fft_len, dim)
+
+        # Check that first column is unchanged (DC component)
+        assert np.array_equal(func_fft[:, 0], np.ones(3))
+        # Check that all other columns are multiplied by 2
+        assert np.array_equal(func_fft[:, 1:], 2 * np.ones((3, 4)))
+
+    def test_odd_fft_length_dim2(self):
+        """Test single_sided_correction with odd FFT length and dim=2."""
+        func_fft = np.ones((2, 3, 5))
+        fft_len = 5
+        dim = 2
+        single_sided_correction(func_fft, fft_len, dim)
+
+        # Check that first slice is unchanged (DC component)
+        assert np.array_equal(func_fft[:, :, 0], np.ones((2, 3)))
+        # Check that all other slices are multiplied by 2
+        assert np.array_equal(func_fft[:, :, 1:], 2 * np.ones((2, 3, 4)))
+
+    def test_odd_fft_length_dim3(self):
+        """Test single_sided_correction with odd FFT length and dim=3."""
+        func_fft = np.ones((2, 2, 2, 5))
+        fft_len = 5
+        dim = 3
+        single_sided_correction(func_fft, fft_len, dim)
+
+        # Check that first hyperslice is unchanged (DC component)
+        assert np.array_equal(func_fft[:, :, :, 0], np.ones((2, 2, 2)))
+        # Check that all other hyperslices are multiplied by 2
+        assert np.array_equal(func_fft[:, :, :, 1:], 2 * np.ones((2, 2, 2, 4)))
+
+    def test_even_fft_length_dim0(self):
+        """Test single_sided_correction with even FFT length and dim=0."""
+        func_fft = np.ones((6, 3))
+        fft_len = 6
+        dim = 0
+        single_sided_correction(func_fft, fft_len, dim)
+
+        # Check that first and last rows are unchanged (DC and Nyquist components)
+        assert np.array_equal(func_fft[0, :], np.ones(3))
+        assert np.array_equal(func_fft[-1, :], np.ones(3))
+        # Check that all other rows are multiplied by 2
+        assert np.array_equal(func_fft[1:-1, :], 2 * np.ones((4, 3)))
+
+    def test_even_fft_length_dim1(self):
+        """Test single_sided_correction with even FFT length and dim=1."""
+        func_fft = np.ones((3, 6))
+        fft_len = 6
+        dim = 1
+        single_sided_correction(func_fft, fft_len, dim)
+
+        # Check that first and last columns are unchanged (DC and Nyquist components)
+        assert np.array_equal(func_fft[:, 0], np.ones(3))
+        assert np.array_equal(func_fft[:, -1], np.ones(3))
+        # Check that all other columns are multiplied by 2
+        assert np.array_equal(func_fft[:, 1:-1], 2 * np.ones((3, 4)))
+
+    def test_even_fft_length_dim2(self):
+        """Test single_sided_correction with even FFT length and dim=2."""
+        func_fft = np.ones((2, 3, 6))
+        fft_len = 6
+        dim = 2
+        single_sided_correction(func_fft, fft_len, dim)
+
+        # Check that first and last slices are unchanged (DC and Nyquist components)
+        assert np.array_equal(func_fft[:, :, 0], np.ones((2, 3)))
+        assert np.array_equal(func_fft[:, :, -1], np.ones((2, 3)))
+        # Check that all other slices are multiplied by 2
+        assert np.array_equal(func_fft[:, :, 1:-1], 2 * np.ones((2, 3, 4)))
+
+    def test_even_fft_length_dim3(self):
+        """Test single_sided_correction with even FFT length and dim=3."""
+        func_fft = np.ones((2, 2, 2, 6))
+        fft_len = 6
+        dim = 3
+        single_sided_correction(func_fft, fft_len, dim)
+
+        # Check that first and last hyperslices are unchanged (DC and Nyquist components)
+        assert np.array_equal(func_fft[:, :, :, 0], np.ones((2, 2, 2)))
+        assert np.array_equal(func_fft[:, :, :, -1], np.ones((2, 2, 2)))
+        # Check that all other hyperslices are multiplied by 2
+        assert np.array_equal(func_fft[:, :, :, 1:-1], 2 * np.ones((2, 2, 2, 4)))
+
+    def test_non_uniform_input(self):
+        """Test single_sided_correction with non-uniform input values."""
+        # Create an array with non-uniform values
+        func_fft = np.ones((6, 3)) * np.arange(1, 7)[:, np.newaxis]
+        func_fft_input = func_fft.copy()
+        fft_len = 6
+        dim = 0
+        single_sided_correction(func_fft, fft_len, dim)
+
+        # Check that the first and last rows are unchanged
+        assert np.array_equal(func_fft[0, :], func_fft_input[0, :])
+        assert np.array_equal(func_fft[-1, :], func_fft_input[-1, :])
+
+        # Check that middle rows are multiplied by 2
+        assert np.array_equal(func_fft[1:-1, :], 2 * func_fft_input[1:-1, :])
+
+    def test_input_preservation(self):
+        """Test that the input array is modified in-place."""
+        func_fft = np.ones((5, 3))
+        fft_len = 5
+        dim = 0
+
+        # Store a reference to the original array
+        original_id = id(func_fft)
+
+        # Apply correction
+        single_sided_correction(func_fft, fft_len, dim)
+
+        # Check that the returned array is the same object
+        assert id(func_fft) == original_id

--- a/tests/test_sharpness_filters.py
+++ b/tests/test_sharpness_filters.py
@@ -1,0 +1,101 @@
+import numpy as np
+
+from kwave.utils.sharpness_filters import brenner_sharpness
+
+
+class TestBrennerSharpness:
+    """Tests for the brenner_sharpness function."""
+
+    def test_2d_constant_image(self):
+        """Test brenner_sharpness with a 2D constant image (should return 0)."""
+        im = np.ones((10, 10))
+        result = brenner_sharpness(im)
+        assert result == 0
+
+    def test_2d_gradient_image(self):
+        """Test brenner_sharpness with a 2D gradient image."""
+        im = np.zeros((10, 10))
+        # Add horizontal gradien
+        for i in range(10):
+            im[:, i] = i
+        result = brenner_sharpness(im)
+        assert result > 0
+
+    def test_2d_edge_image(self):
+        """Test brenner_sharpness with a 2D image containing an edge."""
+        im = np.zeros((10, 10))
+        im[:, 5:] = 1  # Sharp edge in the middle
+        result = brenner_sharpness(im)
+        assert result > 0
+
+    def test_3d_constant_image(self):
+        """Test brenner_sharpness with a 3D constant image (should return 0)."""
+        im = np.ones((5, 5, 5))
+        result = brenner_sharpness(im)
+        assert result == 0
+
+    def test_3d_gradient_image(self):
+        """Test brenner_sharpness with a 3D gradient image."""
+        im = np.zeros((5, 5, 5))
+        # Add gradient in z direction
+        for i in range(5):
+            im[:, :, i] = i
+        result = brenner_sharpness(im)
+        assert result > 0
+
+    def test_3d_edge_image(self):
+        """Test brenner_sharpness with a 3D image containing edges."""
+        im = np.zeros((5, 5, 5))
+        im[:, :, 2:] = 1  # Sharp edge in the middle along z-axis
+        result = brenner_sharpness(im)
+        assert result > 0
+
+    def test_minimum_size_2d(self):
+        """Test brenner_sharpness with a minimum size 2D image that still allows calculation."""
+        # Minimum size is 3x3 due to the [-2:] and [2:] indexing
+        im = np.array([[0, 0, 1], [0, 0, 1], [0, 0, 1]])
+        result = brenner_sharpness(im)
+        assert result >= 0
+
+    def test_minimum_size_3d(self):
+        """Test brenner_sharpness with a minimum size 3D image that still allows calculation."""
+        # Minimum size is 3x3x3 due to the [-2:] and [2:] indexing
+        im = np.zeros((3, 3, 3))
+        im[:, :, 2] = 1  # Set the last slice to 1
+        result = brenner_sharpness(im)
+        assert result >= 0
+
+    def test_relative_sharpness_2d(self):
+        """Test that a sharper 2D image gives higher brenner_sharpness value."""
+        # Create a blurry edge
+        im_blurry = np.zeros((10, 10))
+        im_blurry[:, 3] = 0.25
+        im_blurry[:, 4] = 0.5
+        im_blurry[:, 5] = 0.75
+        im_blurry[:, 6:] = 1.0
+
+        # Create a sharp edge
+        im_sharp = np.zeros((10, 10))
+        im_sharp[:, 5:] = 1.0
+
+        blurry_result = brenner_sharpness(im_blurry)
+        sharp_result = brenner_sharpness(im_sharp)
+
+        assert sharp_result > blurry_result
+
+    def test_relative_sharpness_3d(self):
+        """Test that a sharper 3D image gives higher brenner_sharpness value."""
+        # Create a blurry edge
+        im_blurry = np.zeros((5, 5, 5))
+        im_blurry[:, :, 1] = 0.33
+        im_blurry[:, :, 2] = 0.67
+        im_blurry[:, :, 3:] = 1.0
+
+        # Create a sharp edge
+        im_sharp = np.zeros((5, 5, 5))
+        im_sharp[:, :, 3:] = 1.0
+
+        blurry_result = brenner_sharpness(im_blurry)
+        sharp_result = brenner_sharpness(im_sharp)
+
+        assert sharp_result > blurry_result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,7 +82,7 @@ def test_extract_amp_phase():
     # odd length signal
     test_signal = tone_burst(sample_freq=10_000_000, signal_freq=2.5 * 1_000_000, num_cycles=2, envelope="Gaussian")
     assert np.shape(np.squeeze(test_signal))[0] % 2 != 0
-    a_t, b_t, c_t = extract_amp_phase(data=test_signal, Fs=10_000_000, source_freq=2.5 * 10**6)
+    a_t, b_t, c_t = extract_amp_phase(data=test_signal, fs=10_000_000, source_freq=2.5 * 10**6)
     a, b, c = 0.6547, -1.8035, 2.5926e06
     assert (abs(a_t - a) < 0.01).all()
     assert (abs(b_t - b) < 0.0001).all()
@@ -90,7 +90,7 @@ def test_extract_amp_phase():
     # even length signal
     test_signal = tone_burst(sample_freq=18_000_000, signal_freq=6_000_000, num_cycles=5, envelope="Gaussian")
     assert np.shape(np.squeeze(test_signal))[0] % 2 == 0
-    a_t, b_t, c_t = extract_amp_phase(data=test_signal, Fs=18_000_000, source_freq=6_000_000)
+    a_t, b_t, c_t = extract_amp_phase(data=test_signal, fs=18_000_000, source_freq=6_000_000)
     a, b, c = 0.6591, -1.5708, 6.000e06
     assert (abs(a_t - a) < 0.01).all()
     assert (abs(b_t - b) < 0.0001).all()
@@ -99,7 +99,7 @@ def test_extract_amp_phase():
 
 def test_apply_filter_lowpass():
     test_signal = tone_burst(sample_freq=10_000_000, signal_freq=2.5 * 1_000_000, num_cycles=2, envelope="Gaussian")
-    filtered_signal = apply_filter(test_signal, Fs=1e7, cutoff_f=1e7, filter_type="LowPass")
+    filtered_signal = apply_filter(test_signal, fs=1e7, cutoff_f=1e7, filter_type="LowPass")
     expected_signal = [
         0.00000000e00,
         2.76028757e-24,
@@ -117,7 +117,7 @@ def test_apply_filter_lowpass():
 
 def test_apply_filter_highpass():
     test_signal = tone_burst(sample_freq=10_000_000, signal_freq=2.5 * 1_000_000, num_cycles=2, envelope="Gaussian")
-    filtered_signal = apply_filter(test_signal, Fs=1e7, cutoff_f=1e7, filter_type="HighPass")
+    filtered_signal = apply_filter(test_signal, fs=1e7, cutoff_f=1e7, filter_type="HighPass")
     expected_signal = [
         0.00000000e00,
         1.40844920e-10,
@@ -135,7 +135,7 @@ def test_apply_filter_highpass():
 
 def test_apply_filter_bandpass():
     test_signal = tone_burst(sample_freq=10_000_000, signal_freq=2.5 * 1_000_000, num_cycles=2, envelope="Gaussian")
-    filtered_signal = apply_filter(test_signal, Fs=1e7, cutoff_f=[5e6, 1e7], filter_type="BandPass")
+    filtered_signal = apply_filter(test_signal, fs=1e7, cutoff_f=[5e6, 1e7], filter_type="BandPass")
     expected_signal = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     assert ((abs(filtered_signal - expected_signal)) < 0.0001).all()
     pass


### PR DESCRIPTION
Changes here:
* Simplified `single_sided_correction`'s implementation and added python-side unit tests. Updated to not return anything since input array is modified.
* Extracted sharpness filters to a separate class. In the future, we should convert `filters.py` to a module and categorize the filters under different files in the module.
* Added python-side unit tests to for the Brenner sharpness and simplified its implementation.