### PR TITLE
add run-examples workflow

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -6,9 +6,26 @@ on:
   workflow_dispatch:      # Manual trigger
 
 jobs:
-  run-examples:
+  discover-examples:
     runs-on: ubuntu-latest
-    timeout-minutes: 360  # 6 hour timeout
+    outputs:
+      example_paths: ${{ steps.find-examples.outputs.examples }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: find-examples
+        run: |
+          # Find all Python files in examples subdirectories
+          EXAMPLES=$(find examples -name "*.py" -not -path "*/\.*" | jq -R -s -c 'split("\n")[:-1]')
+          echo "examples=$EXAMPLES" >> "$GITHUB_OUTPUT"
+
+  run-examples:
+    needs: discover-examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 60  # 1 hour timeout per example
+    strategy:
+      fail-fast: false  # Continue running other examples even if one fails
+      matrix:
+        example: ${{ fromJson(needs.discover-examples.outputs.example_paths) }}
     
     steps:
       - name: Checkout repository
@@ -26,7 +43,9 @@ jobs:
           # Install the package with example dependencies
           pip install -e ".[example]"
 
-      - name: Run examples
+      - name: Run example
         env:
           KWAVE_FORCE_CPU: 1
-        run: make run-examples 
+        run: |
+          echo "Running example: ${{ matrix.example }}"
+          python "${{ matrix.example }}" 

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -1,0 +1,32 @@
+name: Run K-Wave Examples
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at 00:00 UTC
+  workflow_dispatch:      # Manual trigger
+
+jobs:
+  run-examples:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360  # 6 hour timeout
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'  # Matches requires-python from pyproject.toml
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Install the package with example dependencies
+          pip install -e ".[example]"
+
+      - name: Run examples
+        env:
+          KWAVE_FORCE_CPU: 1
+        run: make run-examples 

--- a/tests/test_create_pixel_dim.py
+++ b/tests/test_create_pixel_dim.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 
 from kwave.utils.mapgen import create_pixel_dim


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the running of K-Wave examples on a scheduled basis and via manual trigger. The most important changes include setting up the workflow configuration, specifying the environment, and defining the steps for running the examples.

New GitHub Actions workflow:

* [`.github/workflows/run-examples.yml`](diffhunk://#diff-91446d7314e1a0bb6533057d51fbfe57abe3adbf31e3177b1fa63a5799a95442R1-R32): Added a new workflow named "Run K-Wave Examples" that is scheduled to run every Monday at 00:00 UTC and can also be triggered manually. The workflow sets up the environment on `ubuntu-latest`, installs dependencies using Python 3.10, and runs the examples with a 6-hour timeout.