### PR TITLE
bump-darwin to v0.3.0rc3

### DIFF
--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -58,7 +58,7 @@ URL_DICT = {
     },
     "darwin": {
         "cuda": [],
-        "omp": [URL_BASE + f"k-wave-omp-{PLATFORM}/releases/download/v0.3.0rc2/{EXECUTABLE_PREFIX}OMP"],
+        "omp": [URL_BASE + f"k-wave-omp-{PLATFORM}/releases/download/v0.3.0rc3/{EXECUTABLE_PREFIX}OMP"],
     },
     "windows": {architecture: get_windows_release_urls(architecture) for architecture in ARCHITECTURES},
 }


### PR DESCRIPTION
This PR bumps the dependency to the newly released rc3 of the Darwin OMP binary.