### PR TITLE
Add pml_inside parameter to kspaceFirstOrder()

### DIFF
--- a/kwave/kWaveSimulation_helper/expand_grid_matrices.py
+++ b/kwave/kWaveSimulation_helper/expand_grid_matrices.py
@@ -1,3 +1,8 @@
+# Deprecated: this module is part of the legacy kWaveSimulation stack.
+# Use kspaceFirstOrder(pml_inside=False) instead, which handles grid
+# expansion via _expand_for_pml_outside in kspaceFirstOrder.py.
+# Will be deleted in v1.0 (see plans/release-strategy.md).
+
 import logging
 
 import numpy as np

--- a/kwave/kspaceFirstOrder.py
+++ b/kwave/kspaceFirstOrder.py
@@ -9,6 +9,7 @@ from kwave.kmedium import kWaveMedium
 from kwave.ksensor import kSensor
 from kwave.ksource import kSource
 from kwave.ktransducer import NotATransducer
+from kwave.utils.matrix import expand_matrix
 from kwave.utils.pml import get_optimal_pml_size
 
 
@@ -25,6 +26,58 @@ def _normalize_pml(val, ndim, name="pml_size"):
     return t + (t[-1],) * (ndim - len(t))
 
 
+def _is_binary_mask(mask, ndim):
+    """True if mask is a grid-shaped binary array (not Cartesian coordinates)."""
+    arr = np.asarray(mask)
+    if arr.ndim == 2 and arr.shape[0] == ndim:
+        return False  # Cartesian: (ndim, n_points)
+    return True
+
+
+def _expand_for_pml_outside(kgrid, medium, source, sensor, pml_size):
+    """Expand grid/medium/source/sensor so PML sits outside the user domain."""
+    ndim = kgrid.dim
+    new_N = tuple(int(n) + 2 * int(p) for n, p in zip(kgrid.N, pml_size))
+    expanded_kgrid = kWaveGrid(new_N, kgrid.spacing)
+    expanded_kgrid.setTime(kgrid.Nt, kgrid.dt)
+
+    # Medium: edge-extend non-scalar arrays
+    expanded_medium = copy.copy(medium)
+    for attr in ("sound_speed", "density", "alpha_coeff", "BonA"):
+        val = getattr(expanded_medium, attr, None)
+        if val is not None and np.atleast_1d(val).size > 1:
+            setattr(expanded_medium, attr, expand_matrix(np.atleast_1d(val), list(pml_size)))
+
+    # Source: zero-pad spatial arrays
+    expanded_source = copy.copy(source)
+    for attr in ("p0", "p_mask", "u_mask"):
+        val = getattr(expanded_source, attr, None)
+        if val is not None and np.atleast_1d(val).size > 1:
+            setattr(expanded_source, attr, expand_matrix(np.atleast_1d(val), list(pml_size), 0))
+
+    # Sensor: zero-pad binary masks, leave Cartesian unchanged
+    expanded_sensor = sensor
+    if sensor is not None and getattr(sensor, "mask", None) is not None:
+        if _is_binary_mask(sensor.mask, ndim):
+            expanded_sensor = copy.copy(sensor)
+            expanded_sensor.mask = expand_matrix(np.atleast_1d(sensor.mask), list(pml_size), 0)
+
+    return expanded_kgrid, expanded_medium, expanded_source, expanded_sensor
+
+
+def _strip_pml(result, pml_size, ndim):
+    """Remove PML padding from full-grid fields in the result dict."""
+    slices = tuple(slice(int(p), -int(p)) for p in pml_size[:ndim])
+    full_grid_suffixes = ("_final", "_max", "_min", "_rms")
+    stripped = {}
+    for key, val in result.items():
+        if isinstance(val, np.ndarray) and val.ndim == ndim and any(key.endswith(s) for s in full_grid_suffixes):
+            stripped[key] = val[slices]
+        else:
+            stripped[key] = val
+    return stripped
+
+
 def kspaceFirstOrder(
     kgrid: kWaveGrid,
     medium: kWaveMedium,
@@ -33,6 +86,7 @@ def kspaceFirstOrder(
     *,
     pml_size: Union[int, tuple, str] = 20,
     pml_alpha: Union[float, tuple] = 2.0,
+    pml_inside: bool = False,
     use_sg: bool = True,
     use_kspace: bool = True,
     smooth_p0: bool = True,
@@ -66,6 +120,13 @@ def kspaceFirstOrder(
             analysis.  Default ``20``.
         pml_alpha: PML absorption coefficient (Nepers per grid point).
             Scalar or per-dimension tuple.  Default ``2.0``.
+        pml_inside: When ``False`` (default), the grid is automatically
+            expanded by ``2 * pml_size`` so the PML sits outside the user
+            domain; full-grid output fields (``_final``, ``_max``, etc.)
+            are cropped back to the original size.  When ``True``, the PML
+            occupies the outermost grid points of the user-supplied grid,
+            which saves memory but means PML absorption will modify field
+            values near the domain boundary.
         use_sg: Use a staggered grid for velocity fields.  Default ``True``.
         use_kspace: Apply the k-space correction to the time-stepping scheme.
             Default ``True``.
@@ -108,10 +169,33 @@ def kspaceFirstOrder(
 
     validate_simulation(kgrid, medium, source, sensor, pml_size=pml_size)
 
+    # --- Shared pre-processing (both backends) ---
+
+    # Expand grid when PML sits outside the user domain
+    if pml_inside:
+        warnings.warn(
+            f"pml_inside=True: the outermost {pml_size} grid points per side will be used for PML absorption. "
+            "Sources, sensors, and medium properties near the boundary will be affected. "
+            "Set pml_inside=False (default) to expand the grid automatically instead.",
+            stacklevel=2,
+        )
+    if not pml_inside:
+        kgrid, medium, source, sensor = _expand_for_pml_outside(kgrid, medium, source, sensor, pml_size)
+
+    # Smooth initial pressure (after expansion so Blackman window covers PML transition)
+    if smooth_p0 and source.p0 is not None and kgrid.dim >= 2:
+        from kwave.utils.filters import smooth
+
+        source = copy.copy(source)
+        grid_shape = tuple(int(n) for n in kgrid.N)
+        source.p0 = smooth(np.asarray(source.p0, dtype=float).reshape(grid_shape, order="F"), restore_max=True)
+
+    # --- Backend dispatch ---
+
     if backend == "python":
         from kwave.solvers.kspace_solver import Simulation
 
-        return Simulation(
+        result = Simulation(
             kgrid,
             medium,
             source,
@@ -119,12 +203,12 @@ def kspaceFirstOrder(
             device=device,
             use_sg=use_sg,
             use_kspace=use_kspace,
-            smooth_p0=smooth_p0,
+            smooth_p0=False,  # already handled above
             pml_size=pml_size,
             pml_alpha=pml_alpha,
         ).run()
 
-    if backend == "cpp":
+    elif backend == "cpp":
         from kwave.solvers.cpp_simulation import CppSimulation
 
         if not use_kspace:
@@ -143,14 +227,14 @@ def kspaceFirstOrder(
                 stacklevel=2,
             )
 
-        # Apply p0 smoothing before HDF5 serialization (matches MATLAB legacy path)
-        if smooth_p0 and source.p0 is not None and kgrid.dim >= 2:
-            from kwave.utils.filters import smooth
+        # Convert Cartesian sensor mask to binary grid (cpp binary requires binary masks)
+        if sensor is not None and sensor.mask is not None:
+            mask_arr = np.asarray(sensor.mask)
+            if mask_arr.ndim == 2 and mask_arr.shape[0] == kgrid.dim:
+                from kwave.utils.conversion import cart2grid
 
-            source = copy.copy(source)
-            grid_shape = tuple(int(n) for n in kgrid.N)
-            # Fortran (column-major) layout matches MATLAB convention; smooth() is order-agnostic (uses FFT on shape)
-            source.p0 = smooth(np.asarray(source.p0, dtype=float).reshape(grid_shape, order="F"), restore_max=True)
+                sensor = copy.copy(sensor)
+                sensor.mask, _, _ = cart2grid(kgrid, mask_arr)
 
         cpp_sim = CppSimulation(kgrid, medium, source, sensor, pml_size=pml_size, pml_alpha=pml_alpha, use_sg=use_sg)
         if save_only:
@@ -158,4 +242,12 @@ def kspaceFirstOrder(
                 raise ValueError("data_path must be provided when save_only=True " "(the HDF5 files must persist for cluster submission).")
             input_file, output_file = cpp_sim.prepare(data_path=data_path)
             return {"input_file": input_file, "output_file": output_file}
-        return cpp_sim.run(device=device, num_threads=num_threads, device_num=device_num, quiet=quiet, debug=debug, data_path=data_path)
+        result = cpp_sim.run(device=device, num_threads=num_threads, device_num=device_num, quiet=quiet, debug=debug, data_path=data_path)
+
+    # --- Shared post-processing ---
+
+    # Strip PML from full-grid output fields when PML was outside the user domain
+    if not pml_inside and isinstance(result, dict):
+        result = _strip_pml(result, pml_size, kgrid.dim)
+
+    return result

--- a/kwave/kspaceFirstOrder.py
+++ b/kwave/kspaceFirstOrder.py
@@ -22,60 +22,56 @@ def _normalize_pml(val, ndim, name="pml_size"):
     t = tuple(val)
     if len(t) == 0 or len(t) > ndim:
         raise ValueError(f"{name} must be a scalar or 1-to-{ndim}-element sequence, got {len(t)} elements")
-    # Pad short tuples by repeating last value (e.g. (20, 15) in 3-D → (20, 15, 15))
     return t + (t[-1],) * (ndim - len(t))
 
 
-def _is_binary_mask(mask, ndim):
-    """True if mask is a grid-shaped binary array (not Cartesian coordinates)."""
+def _is_cartesian_mask(mask, ndim):
+    """True if mask is a Cartesian coordinate array (ndim, n_points)."""
     arr = np.asarray(mask)
-    if arr.ndim == 2 and arr.shape[0] == ndim:
-        return False  # Cartesian: (ndim, n_points)
-    return True
+    return arr.ndim == 2 and arr.shape[0] == ndim
+
+
+def _expand_obj(obj, attrs, pml_size, edge_val=None):
+    """Shallow-copy obj and expand non-scalar array attributes via expand_matrix."""
+    exp_coeff = list(pml_size)
+    out = copy.copy(obj)
+    for attr in attrs:
+        val = getattr(out, attr, None)
+        if val is not None:
+            arr = np.asarray(val)
+            if arr.size > 1:
+                setattr(out, attr, expand_matrix(arr, exp_coeff, edge_val))
+    return out
 
 
 def _expand_for_pml_outside(kgrid, medium, source, sensor, pml_size):
     """Expand grid/medium/source/sensor so PML sits outside the user domain."""
-    ndim = kgrid.dim
     new_N = tuple(int(n) + 2 * int(p) for n, p in zip(kgrid.N, pml_size))
     expanded_kgrid = kWaveGrid(new_N, kgrid.spacing)
     expanded_kgrid.setTime(kgrid.Nt, kgrid.dt)
 
-    # Medium: edge-extend non-scalar arrays
-    expanded_medium = copy.copy(medium)
-    for attr in ("sound_speed", "density", "alpha_coeff", "BonA"):
-        val = getattr(expanded_medium, attr, None)
-        if val is not None and np.atleast_1d(val).size > 1:
-            setattr(expanded_medium, attr, expand_matrix(np.atleast_1d(val), list(pml_size)))
+    expanded_medium = _expand_obj(medium, ("sound_speed", "density", "alpha_coeff", "BonA"), pml_size)
+    expanded_source = _expand_obj(source, ("p0", "p_mask", "u_mask"), pml_size, edge_val=0)
 
-    # Source: zero-pad spatial arrays
-    expanded_source = copy.copy(source)
-    for attr in ("p0", "p_mask", "u_mask"):
-        val = getattr(expanded_source, attr, None)
-        if val is not None and np.atleast_1d(val).size > 1:
-            setattr(expanded_source, attr, expand_matrix(np.atleast_1d(val), list(pml_size), 0))
-
-    # Sensor: zero-pad binary masks, leave Cartesian unchanged
     expanded_sensor = sensor
     if sensor is not None and getattr(sensor, "mask", None) is not None:
-        if _is_binary_mask(sensor.mask, ndim):
+        if not _is_cartesian_mask(sensor.mask, kgrid.dim):
             expanded_sensor = copy.copy(sensor)
-            expanded_sensor.mask = expand_matrix(np.atleast_1d(sensor.mask), list(pml_size), 0)
+            expanded_sensor.mask = expand_matrix(np.asarray(sensor.mask), list(pml_size), 0)
 
     return expanded_kgrid, expanded_medium, expanded_source, expanded_sensor
 
 
+_FULL_GRID_SUFFIXES = ("_final", "_max", "_min", "_rms")
+
+
 def _strip_pml(result, pml_size, ndim):
     """Remove PML padding from full-grid fields in the result dict."""
-    slices = tuple(slice(int(p), -int(p)) for p in pml_size[:ndim])
-    full_grid_suffixes = ("_final", "_max", "_min", "_rms")
-    stripped = {}
-    for key, val in result.items():
-        if isinstance(val, np.ndarray) and val.ndim == ndim and any(key.endswith(s) for s in full_grid_suffixes):
-            stripped[key] = val[slices]
-        else:
-            stripped[key] = val
-    return stripped
+    slices = tuple(slice(int(p), -int(p) if int(p) else None) for p in pml_size[:ndim])
+    return {
+        key: val[slices] if isinstance(val, np.ndarray) and val.ndim == ndim and any(key.endswith(s) for s in _FULL_GRID_SUFFIXES) else val
+        for key, val in result.items()
+    }
 
 
 def kspaceFirstOrder(
@@ -171,14 +167,6 @@ def kspaceFirstOrder(
 
     # --- Shared pre-processing (both backends) ---
 
-    # Expand grid when PML sits outside the user domain
-    if pml_inside:
-        warnings.warn(
-            f"pml_inside=True: the outermost {pml_size} grid points per side will be used for PML absorption. "
-            "Sources, sensors, and medium properties near the boundary will be affected. "
-            "Set pml_inside=False (default) to expand the grid automatically instead.",
-            stacklevel=2,
-        )
     if not pml_inside:
         kgrid, medium, source, sensor = _expand_for_pml_outside(kgrid, medium, source, sensor, pml_size)
 
@@ -187,8 +175,7 @@ def kspaceFirstOrder(
         from kwave.utils.filters import smooth
 
         source = copy.copy(source)
-        grid_shape = tuple(int(n) for n in kgrid.N)
-        source.p0 = smooth(np.asarray(source.p0, dtype=float).reshape(grid_shape, order="F"), restore_max=True)
+        source.p0 = smooth(np.asarray(source.p0, dtype=float).reshape(tuple(int(n) for n in kgrid.N), order="F"), restore_max=True)
 
     # --- Backend dispatch ---
 
@@ -203,7 +190,7 @@ def kspaceFirstOrder(
             device=device,
             use_sg=use_sg,
             use_kspace=use_kspace,
-            smooth_p0=False,  # already handled above
+            smooth_p0=False,
             pml_size=pml_size,
             pml_alpha=pml_alpha,
         ).run()
@@ -213,41 +200,38 @@ def kspaceFirstOrder(
 
         if not use_kspace:
             warnings.warn(
-                "use_kspace=False has no effect with backend='cpp'; " "the C++ binary always applies k-space correction.",
+                "use_kspace=False has no effect with backend='cpp'; the C++ binary always applies k-space correction.",
                 stacklevel=2,
             )
         if sensor is not None and getattr(sensor, "record", None) is not None:
             warnings.warn(
-                "sensor.record is not yet supported for backend='cpp'; " "the C++ binary will record its default fields.",
+                "sensor.record is not yet supported for backend='cpp'; the C++ binary will record its default fields.",
                 stacklevel=2,
             )
         if sensor is not None and getattr(sensor, "record_start_index", 1) != 1:
             warnings.warn(
-                "sensor.record_start_index is not yet supported for backend='cpp'; " "the C++ binary records from the first time step.",
+                "sensor.record_start_index is not yet supported for backend='cpp'; the C++ binary records from the first time step.",
                 stacklevel=2,
             )
 
         # Convert Cartesian sensor mask to binary grid (cpp binary requires binary masks)
-        if sensor is not None and sensor.mask is not None:
-            mask_arr = np.asarray(sensor.mask)
-            if mask_arr.ndim == 2 and mask_arr.shape[0] == kgrid.dim:
-                from kwave.utils.conversion import cart2grid
+        if sensor is not None and sensor.mask is not None and _is_cartesian_mask(sensor.mask, kgrid.dim):
+            from kwave.utils.conversion import cart2grid
 
-                sensor = copy.copy(sensor)
-                sensor.mask, _, _ = cart2grid(kgrid, mask_arr)
+            sensor = copy.copy(sensor)
+            sensor.mask, _, _ = cart2grid(kgrid, np.asarray(sensor.mask))
 
         cpp_sim = CppSimulation(kgrid, medium, source, sensor, pml_size=pml_size, pml_alpha=pml_alpha, use_sg=use_sg)
         if save_only:
             if data_path is None:
-                raise ValueError("data_path must be provided when save_only=True " "(the HDF5 files must persist for cluster submission).")
+                raise ValueError("data_path must be provided when save_only=True (the HDF5 files must persist for cluster submission).")
             input_file, output_file = cpp_sim.prepare(data_path=data_path)
             return {"input_file": input_file, "output_file": output_file}
         result = cpp_sim.run(device=device, num_threads=num_threads, device_num=device_num, quiet=quiet, debug=debug, data_path=data_path)
 
     # --- Shared post-processing ---
 
-    # Strip PML from full-grid output fields when PML was outside the user domain
-    if not pml_inside and isinstance(result, dict):
+    if not pml_inside:
         result = _strip_pml(result, pml_size, kgrid.dim)
 
     return result

--- a/kwave/kspaceFirstOrder.py
+++ b/kwave/kspaceFirstOrder.py
@@ -226,7 +226,10 @@ def kspaceFirstOrder(
             if data_path is None:
                 raise ValueError("data_path must be provided when save_only=True (the HDF5 files must persist for cluster submission).")
             input_file, output_file = cpp_sim.prepare(data_path=data_path)
-            return {"input_file": input_file, "output_file": output_file}
+            result = {"input_file": input_file, "output_file": output_file}
+            if not pml_inside:
+                result["pml_size"] = pml_size
+            return result
         result = cpp_sim.run(device=device, num_threads=num_threads, device_num=device_num, quiet=quiet, debug=debug, data_path=data_path)
 
     # --- Shared post-processing ---

--- a/kwave/kspaceFirstOrder.py
+++ b/kwave/kspaceFirstOrder.py
@@ -32,14 +32,18 @@ def _is_cartesian_mask(mask, ndim):
 
 
 def _expand_obj(obj, attrs, pml_size, edge_val=None):
-    """Shallow-copy obj and expand non-scalar array attributes via expand_matrix."""
+    """Shallow-copy obj and expand grid-shaped array attributes via expand_matrix.
+
+    Scalars (size == 1) are intentionally skipped — they broadcast to any grid
+    shape and don't need expansion (e.g. homogeneous sound_speed=1500).
+    """
     exp_coeff = list(pml_size)
     out = copy.copy(obj)
     for attr in attrs:
         val = getattr(out, attr, None)
         if val is not None:
             arr = np.asarray(val)
-            if arr.size > 1:
+            if arr.size > 1:  # scalar/homogeneous values broadcast — skip
                 setattr(out, attr, expand_matrix(arr, exp_coeff, edge_val))
     return out
 
@@ -51,6 +55,7 @@ def _expand_for_pml_outside(kgrid, medium, source, sensor, pml_size):
     expanded_kgrid.setTime(kgrid.Nt, kgrid.dt)
 
     expanded_medium = _expand_obj(medium, ("sound_speed", "density", "alpha_coeff", "BonA"), pml_size)
+    # s_mask intentionally excluded — stress sources are not yet implemented (raises NotImplementedError)
     expanded_source = _expand_obj(source, ("p0", "p_mask", "u_mask"), pml_size, edge_val=0)
 
     expanded_sensor = sensor

--- a/kwave/kspaceFirstOrder.py
+++ b/kwave/kspaceFirstOrder.py
@@ -54,7 +54,8 @@ def _expand_for_pml_outside(kgrid, medium, source, sensor, pml_size):
     expanded_kgrid = kWaveGrid(new_N, kgrid.spacing)
     expanded_kgrid.setTime(kgrid.Nt, kgrid.dt)
 
-    expanded_medium = _expand_obj(medium, ("sound_speed", "density", "alpha_coeff", "BonA"), pml_size)
+    expanded_medium = _expand_obj(medium, ("sound_speed", "sound_speed_ref", "density", "alpha_coeff", "BonA"), pml_size)
+    expanded_medium = _expand_obj(expanded_medium, ("alpha_filter",), pml_size, edge_val=0)  # zero-pad, not edge-extend
     # s_mask intentionally excluded — stress sources are not yet implemented (raises NotImplementedError)
     expanded_source = _expand_obj(source, ("p0", "p_mask", "u_mask"), pml_size, edge_val=0)
 

--- a/tests/integration/test_ivp_1D.py
+++ b/tests/integration/test_ivp_1D.py
@@ -36,7 +36,7 @@ def test_ivp_1D_vs_matlab(load_matlab_ref):
     sensor_mask[3 * Nx // 4] = 1
     sensor = kSensor(mask=sensor_mask)
 
-    result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python", smooth_p0=False)
+    result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python", smooth_p0=False, pml_inside=True)
 
     assert int(kgrid.Nt) == int(ref["Nt"])
     np.testing.assert_allclose(float(kgrid.dt), float(ref["dt"]), rtol=1e-12)

--- a/tests/integration/test_ivp_2D.py
+++ b/tests/integration/test_ivp_2D.py
@@ -32,7 +32,7 @@ def test_ivp_2D_vs_matlab(load_matlab_ref):
 
     sensor = kSensor(mask=np.ones((128, 128), dtype=bool))
 
-    result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python")
+    result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python", pml_inside=True)
 
     # Verify time stepping matches
     assert int(kgrid.Nt) == int(ref["Nt"]), f"Nt mismatch: Python {kgrid.Nt} vs MATLAB {ref['Nt']}"

--- a/tests/integration/test_photoacoustic.py
+++ b/tests/integration/test_photoacoustic.py
@@ -43,7 +43,7 @@ def test_photoacoustic_2D_vs_matlab(load_matlab_ref):
     sensor.mask[Nx // 2 + source_sensor_distance - 1, Nx // 2 - 1] = True
     sensor.record = ["p"]
 
-    result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python")
+    result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python", pml_inside=True)
 
     assert_fields_close(result, ref, [("p", "sensor_data_2D_p")])
 
@@ -66,6 +66,6 @@ def test_photoacoustic_3D_vs_matlab(load_matlab_ref):
     sensor.mask[Nx // 2 + source_sensor_distance - 1, Nx // 2 - 1, Nx // 2 - 1] = True
     sensor.record = ["p"]
 
-    result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python")
+    result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python", pml_inside=True)
 
     assert_fields_close(result, ref, [("p", "sensor_data_3D_p")])

--- a/tests/test_native_solver.py
+++ b/tests/test_native_solver.py
@@ -172,7 +172,7 @@ class TestNativePhysics:
         source = kSource()
         source.p0 = np.zeros(64)
         source.p0[32] = 1.0
-        result = kspaceFirstOrder(grid_1d, kWaveMedium(sound_speed=1500), source, None, backend="python")
+        result = kspaceFirstOrder(grid_1d, kWaveMedium(sound_speed=1500), source, None, backend="python", pml_inside=True)
         assert result["p"].shape == (64, 20)
 
 


### PR DESCRIPTION
Shared pre/post-processing for both Python and C++ backends:
- Grid expansion when pml_inside=False (default)
- p0 smoothing hoisted above backend dispatch
- PML stripping from full-grid output fields

The solver (Simulation) stays untouched — it just receives an already-expanded grid and computes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `pml_inside` parameter to `kspaceFirstOrder()`, making PML-outside the default behaviour: the grid is transparently expanded before solver dispatch and full-grid output fields are cropped back to the user's original domain afterwards. The shared pre/post-processing (`_expand_for_pml_outside`, `_strip_pml`, `_expand_obj`) replaces the legacy `expand_grid_matrices.py` path, which is now marked deprecated. The approach is clean and the implementation covers the key medium fields (including the previously-missing `sound_speed_ref` and `alpha_filter`), with comments explaining intentional omissions (`s_mask`).

**Key issues:**

- **Tests not updated in `test_native_solver.py`**: ~8 tests in `TestNative2D` and `TestNativePhysics` use full-grid 64×64 sensor masks (`np.ones((64, 64), dtype=bool)`) and assert shapes like `result["p"].shape == (64 * 64, 10)`. Under the new default `pml_inside=False`, `_expand_for_pml_outside` expands those masks to 104×104 (default `pml_size=20`), so the sensor data will have 10 816 rows instead of 4 096. Only `test_sensor_none_records_everywhere` was updated with `pml_inside=True`; the rest need the same treatment (matching what the integration tests already do).
- **`sensor.directivity.angle` not expanded**: The legacy path (`expand_directivity_angle`) zero-padded this 2-D field; the new helper skips it. Callers who set a directivity sensor in 2-D and rely on `pml_inside=False` will get a shape mismatch at runtime.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge until the un-updated unit tests in test_native_solver.py are fixed — they will fail in CI under the new default.
- The production logic in kspaceFirstOrder.py is well-structured and the medium/source/sensor expansion is largely correct. However, roughly 8 unit tests in TestNative2D and TestNativePhysics were not updated to add `pml_inside=True`, and will deterministically fail because the default pml_outside path expands the 64×64 sensor mask to 104×104, causing all shape assertions against `64*64` to break. This is a clear CI-blocking regression introduced by the PR itself, not a pre-existing issue.
- tests/test_native_solver.py — TestNative2D and TestNativePhysics test methods need pml_inside=True added (or expected shapes updated)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| kwave/kspaceFirstOrder.py | Core change: adds `pml_inside` parameter and three helpers (`_expand_for_pml_outside`, `_strip_pml`, `_expand_obj`). Logic is sound; medium fields (`sound_speed_ref`, `alpha_filter`) are now included and match legacy behaviour. Minor gap: `sensor.directivity.angle` is not expanded. |
| tests/test_native_solver.py | Only `test_sensor_none_records_everywhere` was updated to use `pml_inside=True`; ~8 other tests in `TestNative2D` and `TestNativePhysics` still use full-grid 64×64 sensor masks without the flag and will fail because `_expand_for_pml_outside` expands those masks to 104×104 under the new default. |
| kwave/kWaveSimulation_helper/expand_grid_matrices.py | Only a deprecation comment block was added; no functional changes. |
| tests/integration/test_ivp_1D.py | Correctly adds `pml_inside=True` to preserve comparison with MATLAB reference data generated on the original (unexpanded) grid. |
| tests/integration/test_ivp_2D.py | Correctly adds `pml_inside=True` to preserve MATLAB reference comparison. |
| tests/integration/test_photoacoustic.py | Correctly adds `pml_inside=True` to both 2D and 3D photoacoustic reference tests. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["kspaceFirstOrder(kgrid, medium, source, sensor, ...)"] --> B{pml_inside?}
    B -- "False (default)" --> C["_expand_for_pml_outside()\nnew_N = N + 2*pml_size\nexpand kgrid, medium, source, sensor"]
    B -- "True" --> D["Use grid as-is"]
    C --> E{smooth_p0 and p0 set and dim >= 2?}
    D --> E
    E -- "Yes" --> F["smooth(source.p0) on expanded grid"]
    E -- "No" --> G{backend?}
    F --> G
    G -- "python" --> H["Simulation(..., smooth_p0=False).run()"]
    G -- "cpp" --> I{save_only?}
    I -- "True" --> J["cpp_sim.prepare()\nreturn {input_file, output_file, pml_size}"]
    I -- "False" --> K["cpp_sim.run()"]
    H --> L{pml_inside?}
    K --> L
    L -- "False" --> M["_strip_pml(result)\ncrop _final/_max/_min/_rms fields\nback to original N"]
    L -- "True" --> N["return result as-is"]
    M --> N
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `tests/test_native_solver.py`, line 42-221 ([link](https://github.com/waltsims/k-wave-python/blob/c6236031d6bb290a93611bbcd29c05f5eece3f5d/tests/test_native_solver.py#L42-L221)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Many tests silently run on expanded grids after the new `pml_inside=False` default**

   The majority of tests in `TestNative2D`, `TestNative1D`, `TestNativePhysics`, and `TestCppSaveOnly` (lines 42–221) do not pass `pml_inside=True`. With the new default `pml_inside=False`, they now silently run the solver on a 104×104 expanded grid instead of the intended 64×64. The test assertions happen to still pass because:
   - Sensor-recorded shapes (e.g. `(64*64, 10)`) are unaffected — the sensor mask is expanded with zeros, preserving the 4096 active points.
   - Full-grid fields are stripped back by `_strip_pml`.

   However, the **simulation behavior has changed**: the source, medium, and sensor are all operating on a different grid from what the test author intended. This makes the tests less reliable as regression checks for specific grid-size behavior and makes each 2D test about 2.6× more expensive to run.

   For tests that are deliberately validating numerical output (rather than just checking shapes), please add `pml_inside=True` to preserve the original grid size and physics, matching the intent of the already-updated integration tests (`test_ivp_1D.py`, `test_ivp_2D.py`, `test_photoacoustic.py`).

2. `tests/test_native_solver.py`, line 43-88 ([link](https://github.com/waltsims/k-wave-python/blob/dfe2f7f94fe96f64e995a7f510dc3b653b634df4/tests/test_native_solver.py#L43-L88)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Full-grid sensor tests will fail under the new `pml_inside=False` default**

   The new default `pml_inside=False` causes `_expand_for_pml_outside` to expand the sensor mask from `(64, 64)` → `(104, 104)` (with default `pml_size=20`). Because the binary mask covers the entire 104×104 expanded grid, the solver returns `result["p"]` with shape `(10816, 10)` — not `(4096, 10)`. `_strip_pml` only trims `ndim`-dimensional arrays with `_final`/`_max`/`_min`/`_rms` suffixes; it leaves time-series sensor data untouched.

   Every test in this file that:
   1. uses a full-grid sensor mask (`np.ones((64, 64), dtype=bool)`), and
   2. asserts a shape based on `64 * 64`,

   will now fail. The affected assertions are:

   - `TestNative2D.test_p0_source` (line 46): `result["p"].shape == (64 * 64, 10)` → will be `(10816, 10)`
   - `TestNative2D.test_heterogeneous_medium` (line 59): `result["p"].shape[0] == 64 * 64` → will be `10816`
   - `TestNative2D.test_absorption` (line 69): same as `test_p0_source`
   - `TestNative2D.test_record_aggregates` (line 87): `result["p_max"].shape == (64 * 64,)` → will be `(10816,)` (`_strip_pml` skips 1-D arrays in a 2-D simulation)
   - `TestNativePhysics.test_nonlinearity_bona` (line 122): same shape assertion
   - `TestNativePhysics.test_stokes_absorption` (line 131): same
   - `TestNativePhysics.test_velocity_recording` (lines 149–150): `result["ux"].shape == (64*64, 10)` and `result["ux_max"].shape == (64*64,)` — both fail
   - `TestNativePhysics.test_intensity_recording` (lines 157–158): `result["Ix"].shape == (64*64, 10)` and `result["Ix_avg"].shape == (64*64,)` — both fail

   The fix is to add `pml_inside=True` to each of these calls (matching what `test_ivp_2D.py` and the three integration tests already do), or alternatively update the expected shapes to reflect the expanded-then-cropped-back-to-64×64 sensor data (which would require sensor mask logic changes to keep 64×64 results when using `pml_inside=False`).

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Expand sound_speed_ref and alpha_filter ..."](https://github.com/waltsims/k-wave-python/commit/dfe2f7f94fe96f64e995a7f510dc3b653b634df4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26004712)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->