### PR TITLE
Add kWaveArray python backend tests (all pass — investigate example-s…

### DIFF
--- a/tests/test_kwave_array_python_backend.py
+++ b/tests/test_kwave_array_python_backend.py
@@ -1,0 +1,95 @@
+"""Tests for kWaveArray.combine_sensor_data with the Python backend.
+
+The Python backend returns sensor_data["p"] with shape (n_sensor_points, n_time).
+kWaveArray.combine_sensor_data expects this shape and uses boolean indexing to
+extract per-element data. This test verifies the shapes are compatible.
+"""
+import numpy as np
+import pytest
+
+from kwave.data import Vector
+from kwave.kgrid import kWaveGrid
+from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
+from kwave.ksource import kSource
+from kwave.kspaceFirstOrder import kspaceFirstOrder
+from kwave.utils.kwave_array import kWaveArray
+from kwave.utils.signals import create_cw_signals
+
+
+@pytest.fixture
+def array_sim_2d():
+    """Minimal 2D simulation with a kWaveArray sensor."""
+    grid_size = Vector([64, 64])
+    grid_spacing = Vector([0.1e-3, 0.1e-3])
+    kgrid = kWaveGrid(grid_size, grid_spacing)
+
+    medium = kWaveMedium(sound_speed=1500)
+    kgrid.makeTime(medium.sound_speed)
+
+    # Simple p0 source
+    source = kSource()
+    source.p0 = np.zeros(grid_size)
+    source.p0[32, 32] = 1.0
+
+    # kWaveArray with 2 line elements
+    karray = kWaveArray(bli_tolerance=0.05, upsampling_rate=10)
+    karray.add_line_element([-2e-3, -2e-3], [-2e-3, 2e-3])
+    karray.add_line_element([2e-3, -2e-3], [2e-3, 2e-3])
+
+    sensor = kSensor()
+    sensor.mask = karray.get_array_binary_mask(kgrid)
+
+    return kgrid, medium, source, sensor, karray
+
+
+class TestKWaveArrayPythonBackend:
+    def test_combine_sensor_data_shape(self, array_sim_2d):
+        """combine_sensor_data should work with python backend sensor data."""
+        kgrid, medium, source, sensor, karray = array_sim_2d
+
+        sensor_data = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python")
+
+        # This is the call that fails — boolean index mismatch
+        combined = karray.combine_sensor_data(kgrid, sensor_data["p"])
+
+        assert combined.shape == (karray.number_elements, int(kgrid.Nt))
+
+    def test_sensor_data_shape_matches_mask(self, array_sim_2d):
+        """Python backend sensor data rows should equal number of True points in mask."""
+        kgrid, medium, source, sensor, karray = array_sim_2d
+
+        sensor_data = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python")
+        n_mask_points = int(sensor.mask.sum())
+
+        assert (
+            sensor_data["p"].shape[0] == n_mask_points
+        ), f"sensor_data has {sensor_data['p'].shape[0]} rows but mask has {n_mask_points} True points"
+
+    def test_array_as_sensor_pattern(self):
+        """Reproduce the at_array_as_sensor example pattern: kWaveArray for both source and sensor."""
+        grid_size = Vector([64, 64])
+        grid_spacing = Vector([0.5e-3, 0.5e-3])
+        kgrid = kWaveGrid(grid_size, grid_spacing)
+        medium = kWaveMedium(sound_speed=1500)
+        kgrid.makeTime(medium.sound_speed)
+
+        # kWaveArray used as sensor (like at_array_as_sensor example)
+        karray = kWaveArray(bli_tolerance=0.05, upsampling_rate=10)
+        karray.add_line_element([-10e-3, -10e-3], [-10e-3, 10e-3])
+        karray.add_line_element([10e-3, -10e-3], [10e-3, 10e-3])
+
+        sensor = kSensor()
+        sensor.mask = karray.get_array_binary_mask(kgrid)
+
+        # Time-varying pressure source (not p0)
+        source = kSource()
+        source.p_mask = np.zeros(grid_size)
+        source.p_mask[32, 32] = 1
+        source.p = np.sin(2 * np.pi * 1e6 * kgrid.t_array.squeeze())
+
+        sensor_data = kspaceFirstOrder(kgrid, medium, source, sensor, backend="python")
+
+        # This is the call that fails in the example
+        combined = karray.combine_sensor_data(kgrid, sensor_data["p"])
+        assert combined.shape == (karray.number_elements, int(kgrid.Nt))


### PR DESCRIPTION
…pecific failures separately)

Tests verify combine_sensor_data works with python backend for:
- Simple 2D line sensor array
- Source + sensor pattern (at_array_as_sensor style)
- Shape consistency between sensor_data and binary mask

The actual example failures on port-examples-to-new-api branch may be due to PML-expanded masks or transducer-specific sensor configurations.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new test file (`tests/test_kwave_array_python_backend.py`) that verifies `kWaveArray.combine_sensor_data` works correctly with the Python simulation backend. The tests cover three scenarios: shape consistency between `sensor_data["p"]` and the binary mask, `combine_sensor_data` producing the expected `(n_elements, Nt)` output, and a source+sensor pattern matching the `at_array_as_sensor` example. All tests pass against the existing `kWaveArray` implementation, which itself already handles the `(n_sensor_points, n_time)` shape returned by the Python backend.

Key observations:
- `create_cw_signals` is imported but never used — leftover from prototyping.
- The tests run full `kspaceFirstOrder` simulations but are placed under `tests/` (not `tests/integration/`), so they run in the default test suite without a slow/integration marker, adding significant wall-clock time to CI.
- `test_combine_sensor_data_shape` and `test_sensor_data_shape_matches_mask` both use the same `array_sim_2d` fixture but each execute an independent simulation run, doubling unnecessary compute.
- `tests/integration/test_stubs.py` still marks `kWaveArray` as "not yet supported in Python backend", which is now stale given the evidence in this PR.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; all issues are non-blocking style/organisation concerns with no functional defects in the tests themselves.
- The logic of the three tests is correct: fixtures are valid, shapes asserted match what the implementation produces, and there are no false-positive conditions. The deductions are: unused import, missing integration marker (could slow default CI runs), duplicated simulation, and a stale skip comment in test_stubs.py — none of which affect correctness or merge safety.
- No files require special attention; the only actionable items are minor style and organisation improvements in tests/test_kwave_array_python_backend.py.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/test_kwave_array_python_backend.py | New test file verifying kWaveArray.combine_sensor_data with the Python backend; contains one unused import (create_cw_signals), runs full simulations without an integration marker, and duplicates a simulation across two fixture-sharing tests. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as Test
    participant KA as kWaveArray
    participant KG as kWaveGrid
    participant SIM as kspaceFirstOrder (Python)

    T->>KG: kWaveGrid(grid_size, grid_spacing)
    T->>KG: makeTime(sound_speed)
    T->>KA: kWaveArray(bli_tolerance, upsampling_rate)
    T->>KA: add_line_element(start, end) ×2
    T->>KA: get_array_binary_mask(kgrid)
    KA-->>T: sensor.mask (bool 2D array)
    T->>SIM: kspaceFirstOrder(kgrid, medium, source, sensor, backend="python")
    SIM-->>T: sensor_data {"p": (n_mask_points, Nt)}
    T->>KA: combine_sensor_data(kgrid, sensor_data["p"])
    KA-->>T: combined (n_elements, Nt)
    T->>T: assert combined.shape == (n_elements, Nt)
```

<sub>Reviews (1): Last reviewed commit: ["Add kWaveArray python backend tests (all..."](https://github.com/waltsims/k-wave-python/commit/2743221cda17d4caed8dfdcc9a43e74725feac4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26004801)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->