### PR TITLE
Add 0.6.x subplans: C-order migration, example porting, axisymmetric …

### DIFF
--- a/plans/release-strategy.md
+++ b/plans/release-strategy.md
@@ -10,6 +10,9 @@ This release strategy brings the unified solver architecture to fruition.
 |---------|-----------|-------|
 | **0.5.0** | Finalize master/main | Stabilize current codebase |
 | **0.6.0** | Python Solver + Unified API + Deprecation | Python solver, `kspaceFirstOrder()` kwargs, deprecation warnings |
+| **0.6.1** | C-order Migration (Helpers) | Migrate utils/helpers from F-order to C-order, keep legacy API working |
+| **0.6.2** | Example Migration | Port remaining examples to new `kspaceFirstOrder()` API |
+| **0.6.3** | Axisymmetric Support | Axisymmetric solver in new API, port AS examples |
 | **0.7.0** | CLI (`kwp`) | Command-line interface for running simulations |
 | **1.0.0** | Clean Release | Remove deprecated code. Simple, readable, fast. |
 | **2.0.0** | Performance & Scale | nanobind CUDA, MPI, Devito, multi-GPU |
@@ -121,6 +124,65 @@ warnings.warn(
 
 ---
 
+## Phase 2.1: v0.6.1 - C-order Migration (Helpers)
+
+**Goal:** Migrate helper/utility code from Fortran-order to C-order internally, while keeping the legacy API functional. No user-facing API changes. Fix hacky shaping/indexing throughout.
+
+**Scope:** 55 occurrences of `order="F"` across 10 files. Migrate where possible, keep F-order only at explicit boundaries.
+
+**Migrate (internal helpers — safe to convert):**
+
+| File | `order="F"` count | Notes |
+|------|-------------------|-------|
+| `kwave/utils/matlab.py` | 11 | reshape, flatten, unflatten utilities |
+| `kwave/kgrid.py` | 8 | Grid coordinate generation |
+| `kwave/utils/mapgen.py` | 6 | Map generation |
+| `kwave/utils/conversion.py` | 2 | Unit conversion |
+| `kwave/utils/matrix.py` | 1 | Matrix utilities |
+| `kwave/solvers/kspace_solver.py` | 19 | Audit each: keep F-order only at `simulate_from_dicts` boundary. Convert internal field storage, `_expand_to_grid`, `_build_source_op`, sensor mask extraction. |
+| `kwave/kspaceFirstOrder.py` | 1 | Likely removable |
+
+**Keep as-is (fixed boundaries):**
+
+| File | Reason |
+|------|--------|
+| `kwave/solvers/cpp_simulation.py` | C++ binary expects F-order HDF5 |
+| `kwave/kWaveSimulation.py` | Legacy, deleted in v1.0.0 |
+| `kwave/kWaveSimulation_helper/*` | Legacy, deleted in v1.0.0 |
+
+**Testing:**
+- All existing tests must pass (no behavioral change)
+- Add `tests/test_memory_layout.py`: verify C/F-order input produces identical results, `simulate_from_dicts` round-trips correctly, `cpp_simulation` writes correct F-order HDF5
+
+---
+
+## Phase 2.2: v0.6.2 - Example Migration
+
+**Goal:** Port remaining examples from legacy `kspaceFirstOrder2D/3D` to `kspaceFirstOrder()`.
+
+| Example | Blocker |
+|---------|---------|
+| `pr_2D_TR_line_sensor`, `pr_3D_TR_planar_sensor` | `TimeReversal` class uses legacy API internally |
+| `us_defining_transducer`, `us_beam_patterns`, `us_bmode_linear_transducer`, `us_bmode_phased_array` | `NotATransducer`-as-source pipeline untested with new API |
+| `checkpointing/checkpoint.py` | `checkpoint_file`/`checkpoint_timesteps` not exposed in new API |
+
+---
+
+## Phase 2.3: v0.6.3 - Axisymmetric Support
+
+**Goal:** Add axisymmetric simulation to `kspaceFirstOrder()` and port AS examples.
+
+**Current state:** `kspaceFirstOrderAS.py` / `kspaceFirstOrderASC.py` are standalone entry points. New API hardcodes `axisymmetric_flag=0`.
+
+**Tasks:**
+1. Add `axisymmetric: bool = False` kwarg to `kspaceFirstOrder()`
+2. Implement radial symmetry terms in `Simulation` class (operates on (r, z) grid)
+3. Port `at_circular_piston_AS`, `at_focused_bowl_AS`
+4. Validate against MATLAB references
+5. Deprecate `kspaceFirstOrderAS` / `kspaceFirstOrderASC`
+
+---
+
 ## Phase 3: v1.0.0 - Clean Release
 
 **Goal:** Simple, readable, fast. Remove all deprecated code.
@@ -140,6 +202,17 @@ warnings.warn(
 - `kwave/solvers/serializer.py` (~200 lines)
 
 **Impact:** ~5700 lines → ~1200 lines (-79%)
+
+### Memory Layout and Indexing (v1.0.0)
+
+By v1.0.0, the F→C migration from v0.6.1 should be complete. What remains:
+
+- **C++ HDF5 serialization** (`cpp_simulation.py`) — F-order + 1-based. Stays forever (binary expects this).
+- **MATLAB interop** (`simulate_from_dicts`) — converts F→C on input, C→F on output. Single conversion boundary.
+- **kWaveArray** — rewrite `combine_sensor_data` and `get_distributed_source_signal` to use `np.where` (0-based) and C-order.
+- **sensor.record_start_index** — require 0-based (deprecated 1-based in v0.6.1).
+
+**Principle:** Python-native (C-order, 0-based) everywhere internally. MATLAB compatibility at two explicit boundaries: (1) `simulate_from_dicts` for k-wave-cupy interop, (2) `cpp_simulation._write_hdf5` for the C++ binary.
 
 ---
 
@@ -260,10 +333,13 @@ uv run pytest tests/ -v
 ## Implementation Order
 
 1. **Now:** Finalize master/main for v0.5.0
-2. **Next:** Python solver + `kspaceFirstOrder.py` + deprecation for v0.6.0
-3. **Then:** `kwp` CLI for v0.7.0
-4. **Then:** Clean delete for v1.0.0
-5. **Post-1.0:** Devito, nanobind/MPI based on profiling and user demand
+2. **Next:** Python solver + `kspaceFirstOrder()` API + deprecation for v0.6.0
+3. **Then:** C-order migration of helpers/utils for v0.6.1
+4. **Then:** Port remaining examples to new API for v0.6.2
+5. **Then:** Axisymmetric support in new API for v0.6.3
+6. **Then:** `kwp` CLI for v0.7.0
+7. **Then:** Clean delete for v1.0.0
+8. **Post-1.0:** Devito, nanobind/MPI based on profiling and user demand
 
 ---
 

--- a/plans/release-strategy.md
+++ b/plans/release-strategy.md
@@ -9,7 +9,7 @@ This release strategy brings the unified solver architecture to fruition.
 | Version | Milestone | Focus |
 |---------|-----------|-------|
 | **0.5.0** | Finalize master/main | Stabilize current codebase |
-| **0.6.0** | Python Solver + Unified API + Deprecation | Python solver, `kspaceFirstOrder()` kwargs, deprecation warnings |
+| **0.6.0** | Python Solver + Unified API + Deprecation | Python solver, `kspaceFirstOrder()` kwargs, Future warnings |
 | **0.6.1** | C-order Migration (Helpers) | Migrate utils/helpers from F-order to C-order, keep legacy API working |
 | **0.6.2** | Example Migration | Port remaining examples to new `kspaceFirstOrder()` API |
 | **0.6.3** | Axisymmetric Support | Axisymmetric solver in new API, port AS examples |
@@ -30,7 +30,7 @@ This release strategy brings the unified solver architecture to fruition.
 
 ---
 
-## Phase 2: v0.6.0 - Native Solver + Unified API + Deprecation
+## Phase 2: v0.6.0 - Native Solver + Unified API + Future
 
 **Goal:** Ship a pure Python/CuPy native solver, create a single entry point with kwargs, and deprecate the old API. Three things in one release.
 
@@ -100,14 +100,14 @@ def kspaceFirstOrder2D(kgrid, source, sensor, medium,
 
 **Create:** `kwave/solvers/serializer.py` - Simple HDF5 writer (~200 lines)
 
-### 2c: Deprecation Warnings
+### 2c: Future Warnings
 
-**Add deprecation warnings on old API:**
+**Add Future warnings on old API:**
 ```python
 warnings.warn(
     "SimulationOptions is deprecated. Use kspaceFirstOrder() kwargs instead. "
     "See https://waltersimson.com/k-wave-python/migration",
-    DeprecationWarning
+    FutureWarning
 )
 ```
 
@@ -120,13 +120,13 @@ warnings.warn(
 - `tests/test_native_solver.py` - parity with C++ backend
 - `tests/test_cupy_backend.py` - GPU acceleration (when CUDA available)
 - `tests/test_unified_api.py` - new kwargs API
-- `tests/test_deprecation_warnings.py` - verify warnings emitted
+- `tests/test_Future_warnings.py` - verify warnings emitted
 
 ---
 
 ## Phase 2.1: v0.6.1 - C-order Migration (Helpers)
 
-**Goal:** Migrate helper/utility code from Fortran-order to C-order internally, while keeping the legacy API functional. No structural API changes — deprecation warnings only. Fix hacky shaping/indexing throughout.
+**Goal:** Migrate helper/utility code from Fortran-order to C-order internally, while keeping the legacy API functional. No structural API changes — Future warnings only. Fix hacky shaping/indexing throughout.
 
 **Scope:** 55 occurrences of `order="F"` across 10 files. Migrate where possible, keep F-order only at explicit boundaries.
 
@@ -338,7 +338,7 @@ result = kspaceFirstOrder(kgrid, medium, source, sensor,
 
 **Cross-cutting:**
 - `tests/test_backend_parity.py` — Python vs C++ backends produce same results for shared test cases
-- `tests/test_deprecation_warnings.py` — verify FutureWarning emitted on legacy API calls
+- `tests/test_Future_warnings.py` — verify FutureWarning emitted on legacy API calls
 
 ---
 
@@ -369,8 +369,8 @@ result = kspaceFirstOrder(kgrid, medium, source, sensor, backend='native')
 print('Success:', result['p'].shape)
 "
 
-# v0.6.0 - Deprecation warnings
-uv run python -W error::DeprecationWarning -c "
+# v0.6.0 - Future warnings
+uv run python -W error::FutureWarning -c "
 from kwave.options.simulation_options import SimulationOptions
 "  # Should warn
 
@@ -383,7 +383,7 @@ uv run pytest tests/ -v
 ## Implementation Order
 
 1. **Now:** Finalize master/main for v0.5.0
-2. **Next:** Python solver + `kspaceFirstOrder()` API + deprecation for v0.6.0
+2. **Next:** Python solver + `kspaceFirstOrder()` API + Future for v0.6.0
 3. **Then:** C-order migration of helpers/utils for v0.6.1
 4. **Then:** Port remaining examples to new API for v0.6.2
 5. **Then:** Axisymmetric support in new API for v0.6.3

--- a/plans/release-strategy.md
+++ b/plans/release-strategy.md
@@ -158,13 +158,34 @@ warnings.warn(
 
 ## Phase 2.2: v0.6.2 - Example Migration
 
-**Goal:** Port remaining examples from legacy `kspaceFirstOrder2D/3D` to `kspaceFirstOrder()`.
+**Goal:** Port remaining examples from legacy `kspaceFirstOrder2D/3D` to `kspaceFirstOrder()`, validated against MATLAB reference outputs.
 
-| Example | Blocker |
-|---------|---------|
-| `pr_2D_TR_line_sensor`, `pr_3D_TR_planar_sensor` | `TimeReversal` class uses legacy API internally |
-| `us_defining_transducer`, `us_beam_patterns`, `us_bmode_linear_transducer`, `us_bmode_phased_array` | `NotATransducer`-as-source pipeline untested with new API |
-| `checkpointing/checkpoint.py` | `checkpoint_file`/`checkpoint_timesteps` not exposed in new API |
+### Strategy
+
+Port examples one at a time using MATLAB as ground truth — not old Python results. Use the k-wave-cupy interop layer as the bridge between MATLAB and Python.
+
+**Per-example workflow:**
+
+1. **MATLAB reference** — Run the example in MATLAB k-Wave, save outputs to `.mat`
+2. **k-wave-cupy validation** — Call the Python solver from MATLAB via k-wave-cupy (`simulate_from_dicts`). Compare against MATLAB output. This catches F/C ordering and interop issues at the boundary.
+3. **Standalone Python port** — Port the example to `kspaceFirstOrder()`, compare against the same MATLAB `.mat` reference
+4. **CI fixture** — Add the MATLAB `.mat` as a reference test in `tests/integration/`
+
+**Why k-wave-cupy first:** The interop layer handles F→C conversion at the boundary. Validating there first means ordering bugs are caught before they propagate to the standalone Python example. Once the k-wave-cupy version matches MATLAB, the Python port is a straightforward translation.
+
+**Order of work:**
+1. Migrate example in k-wave-cupy repo (MATLAB calls Python solver)
+2. Validate against MATLAB reference output
+3. Port the standalone Python example in k-wave-python
+4. Add integration test with `.mat` fixture
+
+### Examples to port
+
+| Example | Blocker | Resolution |
+|---------|---------|------------|
+| `pr_2D_TR_line_sensor`, `pr_3D_TR_planar_sensor` | `TimeReversal` class uses legacy API internally | Refactor `TimeReversal` to call `kspaceFirstOrder()` |
+| `us_defining_transducer`, `us_beam_patterns`, `us_bmode_linear_transducer`, `us_bmode_phased_array` | `NotATransducer`-as-source pipeline untested with new API | Validate transducer pipeline end-to-end via k-wave-cupy first |
+| `checkpointing/checkpoint.py` | `checkpoint_file`/`checkpoint_timesteps` not exposed in new API | Add checkpoint kwargs to `kspaceFirstOrder()` |
 
 ---
 

--- a/plans/release-strategy.md
+++ b/plans/release-strategy.md
@@ -126,7 +126,7 @@ warnings.warn(
 
 ## Phase 2.1: v0.6.1 - C-order Migration (Helpers)
 
-**Goal:** Migrate helper/utility code from Fortran-order to C-order internally, while keeping the legacy API functional. No user-facing API changes. Fix hacky shaping/indexing throughout.
+**Goal:** Migrate helper/utility code from Fortran-order to C-order internally, while keeping the legacy API functional. No structural API changes — deprecation warnings only. Fix hacky shaping/indexing throughout.
 
 **Scope:** 55 occurrences of `order="F"` across 10 files. Migrate where possible, keep F-order only at explicit boundaries.
 
@@ -144,11 +144,11 @@ warnings.warn(
 
 **Keep as-is (fixed boundaries):**
 
-| File | Reason |
-|------|--------|
-| `kwave/solvers/cpp_simulation.py` | C++ binary expects F-order HDF5 |
-| `kwave/kWaveSimulation.py` | Legacy, deleted in v1.0.0 |
-| `kwave/kWaveSimulation_helper/*` | Legacy, deleted in v1.0.0 |
+| File | `order="F"` count | Reason |
+|------|-------------------|--------|
+| `kwave/solvers/cpp_simulation.py` | 3 | C++ binary expects F-order HDF5 |
+| `kwave/kWaveSimulation.py` | 1 | Legacy, deleted in v1.0.0 |
+| `kwave/kWaveSimulation_helper/*` | 3 | Legacy, deleted in v1.0.0 |
 
 **Testing:**
 - All existing tests must pass (no behavioral change)

--- a/plans/release-strategy.md
+++ b/plans/release-strategy.md
@@ -193,14 +193,28 @@ Port examples one at a time using MATLAB as ground truth — not old Python resu
 
 **Goal:** Add axisymmetric simulation to `kspaceFirstOrder()` and port AS examples.
 
-**Current state:** `kspaceFirstOrderAS.py` / `kspaceFirstOrderASC.py` are standalone entry points. New API hardcodes `axisymmetric_flag=0`.
+**What axisymmetric means:** Dimensionality reduction for problems with cylindrical symmetry. A 3D symmetric problem is simulated on a 2D (r, z) half-domain; a 2D symmetric problem on a 1D half-domain. Results are mirrored around the symmetry axis to reconstruct the full field.
+
+**Current state:** `kspaceFirstOrderAS.py` / `kspaceFirstOrderASC.py` are standalone entry points using the legacy `kWaveSimulation` pipeline. The new API hardcodes `axisymmetric_flag=0`.
+
+**Design:** Not a separate solver — a wrapper around `kspaceFirstOrder()` that:
+1. Takes `axisymmetric=True` kwarg
+2. Reduces the grid to a half-domain (y ≥ 0 = radial direction)
+3. Adds radial symmetry terms: special PML at axis (no absorption at y=0), expanded grid for FFT symmetries (WSWA: 4× radial, WSWS: 2×-2), radial coordinate vectors for geometric source terms
+4. Runs the lower-dimensional simulation via `Simulation`
+5. Mirrors results around the axis for output
+
+**Legacy mapping:** `kspaceFirstOrderAS` → `kspaceFirstOrder(..., axisymmetric=True, backend="python")`, `kspaceFirstOrderASC` → `kspaceFirstOrder(..., axisymmetric=True, backend="cpp")`
+
+**Constraints:** Staggered grid mandatory (`use_sg=True` enforced). Viscous absorption only (`alpha_power=2` fixed).
 
 **Tasks:**
 1. Add `axisymmetric: bool = False` kwarg to `kspaceFirstOrder()`
-2. Implement radial symmetry terms in `Simulation` class (operates on (r, z) grid)
-3. Port `at_circular_piston_AS`, `at_focused_bowl_AS`
-4. Validate against MATLAB references
-5. Deprecate `kspaceFirstOrderAS` / `kspaceFirstOrderASC`
+2. Implement radial symmetry pre/post-processing in `kspaceFirstOrder()` (grid reduction, PML axis handling, result mirroring)
+3. Add radial terms to `Simulation` class (geometric source terms for (r, z) grid)
+4. Port `at_circular_piston_AS`, `at_focused_bowl_AS` using the v0.6.2 MATLAB-first workflow
+5. Validate against MATLAB references
+6. Deprecate `kspaceFirstOrderAS` / `kspaceFirstOrderASC`
 
 ---
 
@@ -301,15 +315,30 @@ result = kspaceFirstOrder(kgrid, medium, source, sensor,
 ## Testing Strategy
 
 **Existing (keep):**
-- MATLAB reference tests via CI
-- Multi-platform pytest (Windows, Ubuntu, macOS)
-- Python 3.10-3.13 coverage
+- MATLAB reference tests via CI (66 MATLAB collectors → `.mat` fixtures, `scipy.io.loadmat`)
+- Multi-platform pytest (Windows, Ubuntu, macOS) × Python 3.10-3.13 (12-job matrix)
+- Integration tests in `tests/integration/` with `assert_fields_close()` (rtol=1e-10, atol=1e-12)
+- Weekly example runner (`run-examples.yml`, `KWAVE_FORCE_CPU=1`)
 
-**Add:**
-- `tests/test_native_solver.py` - native vs C++ parity
-- `tests/test_unified_api.py` - new kwargs API
-- `tests/test_deprecation_warnings.py` - verify warnings emitted
-- `tests/test_backend_parity.py` - all backends produce same results
+**v0.6.0 (done):**
+- `tests/test_native_solver.py` — 33 tests for Python backend
+- `tests/test_unified_api.py` — new kwargs API
+- `tests/test_compat.py` — `options_to_kwargs()` migration
+
+**v0.6.1 (C-order migration):**
+- `tests/test_memory_layout.py` — C/F-order input produces identical results, `simulate_from_dicts` F→C→F round-trip, `cpp_simulation` writes correct F-order HDF5
+
+**v0.6.2 (example migration):**
+- Per-example MATLAB reference integration tests — validate via k-wave-cupy interop first, then add `.mat` fixtures to `tests/integration/`
+- Each ported example gets a corresponding `test_<example_name>.py` with MATLAB reference comparison
+
+**v0.6.3 (axisymmetric):**
+- Extend existing `test_ivp_axisymmetric_simulation.py` to use new `kspaceFirstOrder(..., axisymmetric=True)` API
+- New MATLAB reference tests for `at_circular_piston_AS`, `at_focused_bowl_AS`
+
+**Cross-cutting:**
+- `tests/test_backend_parity.py` — Python vs C++ backends produce same results for shared test cases
+- `tests/test_deprecation_warnings.py` — verify FutureWarning emitted on legacy API calls
 
 ---
 


### PR DESCRIPTION
…support

Break the 0.6.x release series into incremental milestones:
- 0.6.0: Unified API + Python solver (current scope)
- 0.6.1: Migrate helpers/utils from F-order to C-order
- 0.6.2: Port remaining examples to kspaceFirstOrder()
- 0.6.3: Axisymmetric support in unified API

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR breaks the previously monolithic v0.6.0 milestone into four incremental sub-releases (0.6.0–0.6.3), each with a tightly scoped goal: unified API + Python solver (0.6.0), F→C memory-order migration of helpers (0.6.1), example porting with MATLAB-first validation workflow (0.6.2), and axisymmetric support in the new API (0.6.3). It also resolves earlier review concerns by switching `DeprecationWarning` to `FutureWarning` consistently throughout, adding per-file `order="F"` counts to the "Keep as-is" table so the total reconciles to 55, and qualifying the Phase 2.1 constraint as "No structural API changes — Future warnings only."

Key additions and their fit in the codebase:
- **0.6.1 C-order plan** provides a clear file-by-file migration table and correctly identifies the two permanent F-order boundaries (`cpp_simulation.py` HDF5 writes, `simulate_from_dicts` interop).
- **0.6.2 example migration** introduces a disciplined MATLAB→k-wave-cupy→standalone-Python validation chain that should prevent ordering bugs from silently propagating to ported examples.
- **0.6.3 axisymmetric** design specifies the half-domain reduction, PML axis handling, and WSWA/WSWS grid expansion, with explicit legacy-entry-point deprecation tasks.
- Two minor issues remain: the roadmap table Milestone cell for 0.6.0 still says "Deprecation" (not updated in this PR), and the proposed test file `test_Future_warnings.py` uses a non-standard capitalised `F` that should be `test_future_warnings.py` per Python/pytest conventions.

<h3>Confidence Score: 5/5</h3>

Documentation-only change, safe to merge; remaining issues are cosmetic nits.

This PR touches only a planning document. Previous reviewer concerns (FutureWarning vs DeprecationWarning inconsistency, F-order count mismatch, "no user-facing changes" contradiction with the record_start_index deprecation) are all addressed. The two remaining findings (stale "Deprecation" label in the roadmap table, non-standard test file capitalisation) are purely cosmetic and carry no runtime risk.

No files require special attention; all changes are in plans/release-strategy.md.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| plans/release-strategy.md | Adds detailed sub-milestones 0.6.1–0.6.3 (C-order migration, example porting, axisymmetric support) and standardises on FutureWarning throughout; two minor inconsistencies remain: stale "Deprecation" label in the roadmap table (line 12) and non-standard capitalisation in the proposed test file name `test_Future_warnings.py` (lines 123, 341). |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["v0.5.0\nStabilize master/main"] --> B["v0.6.0\nUnified API + Python Solver\n+ FutureWarnings on legacy API"]
    B --> C["v0.6.1\nC-order migration\n(helpers / utils)"]
    C --> D["v0.6.2\nExample migration\n(MATLAB-first workflow)"]
    D --> E["v0.6.3\nAxisymmetric support\nin kspaceFirstOrder()"]
    E --> F["v0.7.0\nCLI (kwp)"]
    F --> G["v1.0.0\nClean Release\n(remove deprecated code)"]
    G --> H["v2.0.0\nPerformance & Scale\n(nanobind, MPI, Devito)"]

    subgraph "0.6.x sub-milestones (this PR)"
      B
      C
      D
      E
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `plans/release-strategy.md`, line 190-204 ([link](https://github.com/waltsims/k-wave-python/blob/50bf3c94191617ade4bb26fa83c9d2e6a35c182d/plans/release-strategy.md#L190-L204)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Implicit rename of `kspace_solver.py` → `simulation.py` never stated**

   Phase 2a (v0.6.0) introduces the `Simulation` class in `kwave/solvers/kspace_solver.py`. The v1.0.0 "Keep simplified" list then references `kwave/solvers/simulation.py` (~500 lines) without ever explaining that this is a rename. Meanwhile, the Critical Files table at the bottom still points to `kspace_solver.py`.

   The Delete list for v1.0.0 also omits `kspace_solver.py` entirely, which could leave readers unsure whether it's kept, renamed, or accidentally forgotten.

   If the intent is a rename, spelling it out explicitly (e.g., a "Rename `kspace_solver.py` → `simulation.py`" entry in the v1.0.0 task list) would eliminate ambiguity and allow the Critical Files table to be updated accordingly.

2. `plans/release-strategy.md`, line 368 ([link](https://github.com/waltsims/k-wave-python/blob/8ea66493bad02ff7ed8b9003b80a1cc093d1eeed/plans/release-strategy.md#L368)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`backend='native'` not a valid value per the API spec**

   The verification snippet on this line uses `backend='native'`, but the API signature defined earlier only accepts `"cpp"` or `"python"`:

   ```python
   backend: str = "cpp",  # "cpp" or "python"
   ```

   If this snippet is copy-pasted into a test or migration guide it will silently pass a bad value (or raise an error, depending on validation). Pick one name and use it consistently throughout the document.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["replace dep with future"](https://github.com/waltsims/k-wave-python/commit/28d915aecdc507d1b499da45fcaeae5a7afecc5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26505493)</sub>

<!-- /greptile_comment -->