### PR TITLE
Add unified API docs and bump version to 0.6.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,25 @@
 This project is a Python implementation of v1.4.0 of the [MATLAB toolbox k-Wave](http://www.k-wave.org/) as well as an
 interface to the pre-compiled v1.3 of k-Wave simulation binaries, which support NVIDIA sm 5.0 (Maxwell) to sm 9.0a (Hopper) GPUs.
 
+## What's New in v0.6.0
+
+**Unified API:** A single `kspaceFirstOrder()` function replaces `kspaceFirstOrder2D` / `3D` and their options classes.
+Dimensionality is auto-detected from the grid. All simulation parameters are keyword arguments.
+
+**Python solver:** A pure NumPy/CuPy solver runs 1D, 2D, and 3D simulations without the C++ binary.
+Use `device="gpu"` for GPU acceleration via CuPy.
+
+```python
+from kwave.kspaceFirstOrder import kspaceFirstOrder
+
+result = kspaceFirstOrder(kgrid, medium, source, sensor)           # NumPy CPU
+result = kspaceFirstOrder(kgrid, medium, source, sensor, device="gpu")  # CuPy GPU
+result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="cpp") # C++ binary
+```
+
+The legacy `kspaceFirstOrder2D` / `3D` functions still work but emit deprecation warnings.
+See the [Unified API guide](https://k-wave-python.readthedocs.io/en/latest/get_started/new_api.html) for migration details.
+
 ## Mission
 
 With this project, we hope to increase the accessibility and reproducibility of [k-Wave](http://www.k-wave.org/) simulations

--- a/docs/get_started/first_simulation.rst
+++ b/docs/get_started/first_simulation.rst
@@ -138,20 +138,27 @@ Sensors specify where we record the acoustic data:
 Step 5: Run the Simulation
 --------------------------
 
-Now we combine all four components and run the simulation:
+Now we combine all four components and run:
 
 .. code-block:: python
 
-   from kwave import kspaceFirstOrder2D
-   
-   # Run the simulation
-   sensor_data = kspaceFirstOrder2D(
-       grid=grid,
-       medium=medium, 
-       source=source,
-       sensor=sensor,
-       simulation_options={'PMLInside': False, 'PlotSim': False}
+   from kwave.kspaceFirstOrder import kspaceFirstOrder
+
+   # Run with the NumPy/CuPy backend in Python
+   sensor_data = kspaceFirstOrder(
+       grid, medium, source, sensor,
+       pml_inside=False,
+       quiet=True,
    )
+
+.. note::
+
+   ``kspaceFirstOrder()`` is the unified entry point introduced in v0.6.0.
+   It auto-detects dimensionality from the grid and replaces the legacy
+   ``kspaceFirstOrder2D`` / ``3D`` functions. See :doc:`/get_started/new_api`
+   for details.
+
+   The legacy functions still work but emit deprecation warnings.
 
 Step 6: Visualize Results
 -------------------------

--- a/docs/get_started/new_api.rst
+++ b/docs/get_started/new_api.rst
@@ -139,17 +139,3 @@ arguments:
 
 The legacy ``kspaceFirstOrder2D`` and ``kspaceFirstOrder3D`` functions
 continue to work but emit ``DeprecationWarning``.
-
-Environment Variables
----------------------
-
-Two environment variables override the ``backend`` and ``device`` parameters
-for all ``kspaceFirstOrder()`` calls.  Useful for CI and cluster environments:
-
-- ``KWAVE_BACKEND`` — set to ``"python"`` or ``"cpp"``
-- ``KWAVE_DEVICE`` — set to ``"cpu"`` or ``"gpu"``
-
-.. code-block:: bash
-
-   # Run all simulations with the Python backend on CPU
-   KWAVE_BACKEND=python KWAVE_DEVICE=cpu python my_script.py

--- a/docs/get_started/new_api.rst
+++ b/docs/get_started/new_api.rst
@@ -1,0 +1,155 @@
+Unified API (v0.6.0)
+====================
+
+Starting with v0.6.0, ``kspaceFirstOrder()`` is the preferred way to run
+simulations.  It replaces the legacy ``kspaceFirstOrder2D``,
+``kspaceFirstOrder3D``, and their GPU variants with a single function that
+auto-detects dimensionality from the grid.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+Quick Start
+-----------
+
+.. code-block:: python
+
+   from kwave.kgrid import kWaveGrid
+   from kwave.kmedium import kWaveMedium
+   from kwave.ksource import kSource
+   from kwave.ksensor import kSensor
+   from kwave.kspaceFirstOrder import kspaceFirstOrder
+   import numpy as np
+
+   # Setup (works for 1D, 2D, or 3D — just change grid dimensions)
+   kgrid = kWaveGrid([128, 128], [0.1e-3, 0.1e-3])
+   kgrid.makeTime(1500)
+
+   medium = kWaveMedium(sound_speed=1500, density=1000)
+
+   source = kSource()
+   source.p0 = np.zeros((128, 128))
+   source.p0[64, 64] = 1.0
+
+   sensor = kSensor(mask=np.ones((128, 128), dtype=bool))
+
+   # Run with the NumPy/CuPy solver in Python
+   result = kspaceFirstOrder(kgrid, medium, source, sensor)
+
+   print(result["p"].shape)       # (16384, Nt) — time series at each sensor
+   print(result["p_final"].shape) # (128, 128)  — final pressure field
+
+Backend and Device
+------------------
+
+Two independent choices control how the simulation runs:
+
+- **backend** selects the simulation engine:
+
+  - ``"python"`` (default) — pure Python solver using NumPy or CuPy.
+    No external dependencies beyond NumPy.
+  - ``"cpp"`` — serializes to HDF5 and invokes the pre-compiled C++ binary.
+    Requires FFTW (``brew install fftw`` on macOS).
+
+- **device** selects the hardware:
+
+  - ``"cpu"`` (default) — NumPy for ``backend="python"``, OMP binary for
+    ``backend="cpp"``.
+  - ``"gpu"`` — CuPy for ``backend="python"`` (requires CuPy + CUDA),
+    CUDA binary for ``backend="cpp"``.
+
+.. code-block:: python
+
+   # NumPy on CPU (default)
+   result = kspaceFirstOrder(kgrid, medium, source, sensor)
+
+   # CuPy on GPU (requires CuPy + CUDA)
+   result = kspaceFirstOrder(kgrid, medium, source, sensor, device="gpu")
+
+   # C++ binary on CPU (requires FFTW)
+   result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="cpp")
+
+   # C++ CUDA binary on GPU
+   result = kspaceFirstOrder(kgrid, medium, source, sensor, backend="cpp", device="gpu")
+
+PML Options
+-----------
+
+The perfectly-matched layer (PML) absorbs outgoing waves at the domain
+boundary.  Three controls:
+
+.. code-block:: python
+
+   # Fixed size (default: 20 grid points on all sides)
+   result = kspaceFirstOrder(kgrid, medium, source, sensor, pml_size=20)
+
+   # Per-dimension sizes
+   result = kspaceFirstOrder(kgrid, medium, source, sensor, pml_size=(10, 15))
+
+   # Auto-optimal size (computed from grid via FFT analysis)
+   result = kspaceFirstOrder(kgrid, medium, source, sensor, pml_size="auto")
+
+   # PML inside the user domain (saves memory, but PML overlaps your grid)
+   result = kspaceFirstOrder(kgrid, medium, source, sensor, pml_inside=True)
+
+By default (``pml_inside=False``), the grid is automatically expanded so
+the PML sits outside your domain.  Full-grid output fields (``_final``,
+``_max``, etc.) are cropped back to the original size.
+
+Save-Only Mode (Cluster Submission)
+------------------------------------
+
+Generate HDF5 input files for the C++ binary without running it:
+
+.. code-block:: python
+
+   result = kspaceFirstOrder(
+       kgrid, medium, source, sensor,
+       backend="cpp",
+       save_only=True,
+       data_path="/path/to/output",
+   )
+   print(result["input_file"])   # path to HDF5 input
+   print(result["output_file"])  # path where C++ will write results
+
+Full Parameter Reference
+------------------------
+
+.. autofunction:: kwave.kspaceFirstOrder.kspaceFirstOrder
+
+Migrating from Legacy API
+--------------------------
+
+The ``kwave.compat`` module provides ``options_to_kwargs()`` to convert
+old ``SimulationOptions`` / ``SimulationExecutionOptions`` to keyword
+arguments:
+
+.. code-block:: python
+
+   from kwave.compat import options_to_kwargs
+   from kwave.options.simulation_options import SimulationOptions
+   from kwave.options.simulation_execution_options import SimulationExecutionOptions
+
+   sim_opts = SimulationOptions(smooth_p0=False, pml_inside=True)
+   exec_opts = SimulationExecutionOptions(is_gpu_simulation=False)
+
+   kwargs = options_to_kwargs(simulation_options=sim_opts, execution_options=exec_opts)
+   result = kspaceFirstOrder(kgrid, medium, source, sensor, **kwargs)
+
+The legacy ``kspaceFirstOrder2D`` and ``kspaceFirstOrder3D`` functions
+continue to work but emit ``DeprecationWarning``.
+
+Environment Variables
+---------------------
+
+Two environment variables override the ``backend`` and ``device`` parameters
+for all ``kspaceFirstOrder()`` calls.  Useful for CI and cluster environments:
+
+- ``KWAVE_BACKEND`` — set to ``"python"`` or ``"cpp"``
+- ``KWAVE_DEVICE`` — set to ``"cpu"`` or ``"gpu"``
+
+.. code-block:: bash
+
+   # Run all simulations with the Python backend on CPU
+   KWAVE_BACKEND=python KWAVE_DEVICE=cpu python my_script.py

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ k-Wave is an open source acoustics toolbox for MATLAB and C++ developed by Bradl
    :hidden:
 
    get_started/first_simulation
+   get_started/new_api
    get_started/grid_overview
    get_started/medium_overview
    get_started/source_overview
@@ -29,6 +30,7 @@ k-Wave is an open source acoustics toolbox for MATLAB and C++ developed by Bradl
    kwave.kmedium
    kwave.ksource
    kwave.ksensor
+   kwave.kspaceFirstOrder
    kwave.kWaveSimulation
    kwave.kspaceFirstOrder2D
    kwave.kspaceFirstOrder3D

--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -9,7 +9,7 @@ from urllib.request import urlretrieve
 
 # Test installation with:
 # python3 -m pip install -i https://test.pypi.org/simple/ --extra-index-url=https://pypi.org/simple/ k-Wave-python==0.3.0
-__version__ = "0.5.0rc1"
+__version__ = "0.6.0"
 
 # Constants and Configurations
 URL_BASE = "https://github.com/waltsims/"

--- a/kwave/compat.py
+++ b/kwave/compat.py
@@ -34,6 +34,7 @@ def options_to_kwargs(simulation_options=None, execution_options=None):
         elif opts.pml_alpha is not None:
             kwargs["pml_alpha"] = opts.pml_alpha
 
+        kwargs["pml_inside"] = opts.pml_inside
         kwargs["use_sg"] = opts.use_sg
         kwargs["use_kspace"] = opts.use_kspace
         kwargs["smooth_p0"] = opts.smooth_p0


### PR DESCRIPTION
- Add new_api.rst guide covering kspaceFirstOrder() usage, backend/device selection, PML options, save-only mode, migration from legacy API
- Update first_simulation.rst to use kspaceFirstOrder() instead of legacy
- Add kspaceFirstOrder to docs index and API toctree
- Update README with What's New in v0.6.0 section
- Bump version from 0.5.0rc1 to 0.6.0

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the v0.6.0 unified API documentation and bumps the version from `0.5.0rc1` to `0.6.0`. It adds a comprehensive `new_api.rst` guide, updates `first_simulation.rst` to use the new `kspaceFirstOrder()` entry point, wires everything into the docs index and API toctree, and makes one functional fix in `kwave/compat.py`.\n\n**Key changes:**\n- **New `docs/get_started/new_api.rst`** — covers quick start, backend/device selection, PML options, save-only cluster mode, a full parameter reference via `autofunction`, and a migration guide from the legacy options classes.\n- **`kwave/compat.py` functional fix** — `options_to_kwargs()` now unconditionally maps `pml_inside` from `SimulationOptions` to the kwargs dict, resolving the previously-flagged silent divergence between the legacy default (`True`) and the new API default (`False`) during migration.\n- **Environment-variables section removed** — the previously-flagged undocumented `KWAVE_BACKEND`/`KWAVE_DEVICE` section is absent from `new_api.rst`, correctly deferring that feature until it is actually implemented.\n- **Version bump** — `__version__` updated to `\"0.6.0\"` in `kwave/__init__.py`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both previously-flagged concerns are resolved and no new issues are introduced.

Both prior review concerns are addressed: `pml_inside` is now correctly forwarded by `options_to_kwargs()`, and the unimplemented environment-variables section was removed rather than shipped. The remaining changes are documentation and a version bump with no observable runtime risk.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| kwave/compat.py | Adds `pml_inside` to the unconditional kwargs mapping in `options_to_kwargs()`, fixing the previously-flagged silent data loss when migrating code that relied on a non-default `pml_inside` value. |
| kwave/__init__.py | Straightforward version bump from `0.5.0rc1` to `0.6.0`. |
| docs/get_started/new_api.rst | New Unified API guide covering quick start, backend/device selection, PML options, save-only mode, and migration from the legacy API; environment-variables section previously flagged is absent, and the migration example now works correctly following the compat.py fix. |
| docs/get_started/first_simulation.rst | Step 5 updated to use `kspaceFirstOrder()` instead of `kspaceFirstOrder2D`; a note is added explaining the unified API and pointing to the new guide. |
| docs/index.rst | Adds `get_started/new_api` to the toctree and `kwave.kspaceFirstOrder` to the API reference section. |
| docs/README.md | Adds a "What's New in v0.6.0" section advertising the unified API, Python solver, and a link to the new guide. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["options_to_kwargs(simulation_options, execution_options)"] --> B{simulation_options?}
    B -- yes --> C{pml_auto?}
    C -- yes --> D["pml_size = 'auto'"]
    C -- no --> E{pml_x_size set?}
    E -- yes --> F["pml_size = per-dim tuple/scalar"]
    E -- no --> G{pml_size set?}
    G -- yes --> H["pml_size = scalar/tuple"]
    D & F & H --> I["pml_alpha mapping"]
    I --> J["pml_inside = opts.pml_inside (new)"]
    J --> K["use_sg, use_kspace, smooth_p0, data_path, save_only"]
    B -- no --> L
    K --> L{execution_options?}
    L -- yes --> M{backend value?}
    M -- python --> N["backend='python', device=cpu/gpu"]
    M -- CUDA --> O["backend='cpp', device='gpu'"]
    M -- OMP --> P["backend='cpp', device='cpu'"]
    M -- other/None --> Q["backend='cpp', device via is_gpu"]
    N & O & P & Q --> R["quiet/debug/num_threads/device_num"]
    L -- no --> S
    R --> S["return kwargs"]
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;master&#39; into docs-new-api-..."](https://github.com/waltsims/k-wave-python/commit/102645859c057a7454e6057f7a0501954ea6bb82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26510627)</sub>

<!-- /greptile_comment -->