### PR TITLE
Exclude k-wave.org from link checker — site is returning 500

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -30,5 +30,6 @@ jobs:
             --exclude "https://pubs.aip.org"
             --exclude "https://www.gnu.org"
             --exclude "https://fsf.org"
+            --exclude "http://www.k-wave.org"
             "**/*.md" "**/*.rst"
           fail: true


### PR DESCRIPTION
The k-wave.org website is temporarily down (500 Internal Server Error). Our links are correct; exclude the domain until the site recovers.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR temporarily excludes `k-wave.org` from the lychee link-checker workflow while the site is returning 500 errors, preventing CI failures caused by an external outage rather than broken links in the docs.\n\n- Adds a single `--exclude` entry for `http://www.k-wave.org` to `.github/workflows/link-check.yml`\n- The exclusion pattern uses `http://` only, which may not cover `https://www.k-wave.org`, `http://k-wave.org`, or `https://k-wave.org` variants that could appear in docs — a domain-level regex like `k-wave\\.org` would provide a more complete blanket exclusion

<h3>Confidence Score: 4/5</h3>

Safe to merge, but the exclusion pattern may leave HTTPS/non-www links uncovered and still failing CI.

The change is a straightforward, low-risk CI fix. The only concrete issue is that the `http://www.k-wave.org` exclusion pattern may not catch all URL variants, meaning the link checker could still fail for HTTPS or subdomain-free references to the same domain. Broadening the pattern to `k-wave\.org` would fully resolve the intent.

.github/workflows/link-check.yml — verify the exclusion regex covers all URL forms used in docs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/link-check.yml | Adds `--exclude "http://www.k-wave.org"` to the lychee link checker; the HTTP-only, www-prefixed pattern may not cover all URL variants used in docs. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Exclude k-wave.org from link checker — s..."](https://github.com/waltsims/k-wave-python/commit/5b3dfdbd631450a6dd0e081cf4d7ee6e8f373453) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26535775)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->