### PR TITLE
Remove unrelated test_example_parity.py change

### DIFF
--- a/.github/workflows/test_pages.yml
+++ b/.github/workflows/test_pages.yml
@@ -12,6 +12,12 @@ jobs:
       with:
         python-version: '3.10'
         cache: 'pip'
+    - name: Install pandoc
+      run: sudo apt-get update && sudo apt-get install -y pandoc
+    - name: Install dependencies
+      run: pip install '.[docs]'
+    - name: Generate example notebooks
+      run: python docs/generate_example_notebooks.py
     - name: Build and Commit
       uses: waltsims/pages@pyproject.toml-support
       with:

--- a/.github/workflows/test_pages.yml
+++ b/.github/workflows/test_pages.yml
@@ -14,11 +14,9 @@ jobs:
         cache: 'pip'
     - name: Install pandoc
       run: sudo apt-get update && sudo apt-get install -y pandoc
-    - name: Install dependencies
-      run: pip install '.[docs]'
-    - name: Generate example notebooks
-      run: python docs/generate_example_notebooks.py
+    - name: Install dependencies and generate notebooks
+      run: |
+        pip install '.[docs]'
+        python docs/generate_example_notebooks.py
     - name: Build and Commit
       uses: waltsims/pages@pyproject.toml-support
-      with:
-        pyproject_toml_deps: ".[docs]"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build/
 src/
 transfer_temp/
 docs/_build/
+docs/_examples/
 kwave/bin/
 
 # Package manager files

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,15 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile notebooks
+
+# Convert example .py files to notebooks in _examples/ before the Sphinx build.
+notebooks:
+	python generate_example_notebooks.py
+
+# Override the html target to run notebook conversion first.
+html: notebooks
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_mdinclude",
     "sphinx.ext.extlinks",  # Enables :ghfile: external links
+    "nbsphinx",
 ]
 
 # Provide a simple GitHub branch/sha fallback for linking to example files.
@@ -64,6 +65,26 @@ extlinks = {
         "%s",
     ),
 }
+
+# -- Options for nbsphinx ----------------------------------------------------
+# Do not execute notebooks during the Sphinx build; they are pre-rendered.
+nbsphinx_execute = "never"
+
+# Add an "Open in Colab" badge at the top of every notebook page.
+nbsphinx_prolog = r"""
+{% set docname = env.doc2path(env.docname, base=None) %}
+{% set nb_name = docname.split('/')[-1] %}
+
+.. raw:: html
+
+    <p>
+      <a href="https://colab.research.google.com/github/waltsims/k-wave-python/blob/master/notebooks/{{ nb_name }}">
+        <img alt="Open In Colab"
+             src="https://colab.research.google.com/assets/colab-badge.svg"
+             style="vertical-align:text-bottom">
+      </a>
+    </p>
+"""
 
 source_suffix = [".rst", ".md"]
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,12 +73,12 @@ nbsphinx_execute = "never"
 # Add an "Open in Colab" badge at the top of every notebook page.
 nbsphinx_prolog = r"""
 {% set docname = env.doc2path(env.docname, base=None) %}
-{% set nb_name = docname.split('/')[-1] %}
+{% set nb_basename = docname.split('/')[-1].replace('.ipynb', '') %}
 
 .. raw:: html
 
     <p>
-      <a href="https://colab.research.google.com/github/waltsims/k-wave-python/blob/master/notebooks/{{ nb_name }}">
+      <a href="https://colab.research.google.com/github/waltsims/k-wave-python/blob/master/notebooks/{{ nb_basename }}.ipynb">
         <img alt="Open In Colab"
              src="https://colab.research.google.com/assets/colab-badge.svg"
              style="vertical-align:text-bottom">

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,70 @@
+Example Gallery
+===============
+
+Interactive notebook versions of the k-Wave-python examples.
+Each page includes an **Open in Colab** badge so you can run the code in the
+cloud without any local setup.
+
+Initial Value Problems (IVP)
+----------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   _examples/ivp_homogeneous_medium
+   _examples/ivp_heterogeneous_medium
+   _examples/ivp_photoacoustic_waveforms
+   _examples/ivp_recording_particle_velocity
+   _examples/ivp_binary_sensor_mask
+   _examples/ivp_loading_external_image
+   _examples/ivp_saving_movie_files
+   _examples/ivp_1D_simulation
+   _examples/ivp_3D_simulation
+
+Time-Varying Pressure Sources (TVSP)
+-------------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   _examples/tvsp_homogeneous_medium_monopole
+   _examples/tvsp_homogeneous_medium_dipole
+   _examples/tvsp_steering_linear_array
+   _examples/tvsp_snells_law
+   _examples/tvsp_doppler_effect
+   _examples/tvsp_3D_simulation
+
+Sensor Directivity (SD)
+------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   _examples/sd_directivity_modelling_2D
+   _examples/sd_directivity_modelling_3D
+   _examples/sd_focussed_detector_2D
+   _examples/sd_focussed_detector_3D
+   _examples/sd_directional_array_elements
+
+Photoacoustic Reconstruction (PR)
+----------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   _examples/pr_2D_FFT_line_sensor
+   _examples/pr_3D_FFT_planar_sensor
+
+Numerical Analysis (NA)
+------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   _examples/na_controlling_the_PML
+   _examples/na_source_smoothing
+   _examples/na_filtering_part_1
+   _examples/na_filtering_part_2
+   _examples/na_filtering_part_3
+   _examples/na_modelling_nonlinearity
+   _examples/na_optimising_performance

--- a/docs/generate_example_notebooks.py
+++ b/docs/generate_example_notebooks.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Convert examples/*.py (jupytext percent format) to docs/_examples/*.ipynb.
+
+Run this before the Sphinx build so that nbsphinx can render them.
+
+Usage:
+    python docs/generate_example_notebooks.py
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples"
+OUTPUT_DIR = REPO_ROOT / "docs" / "_examples"
+
+
+def _promote_docstring_to_markdown(nb_path: Path) -> None:
+    """If the first cell is a code cell whose only content is a docstring,
+    convert it to a markdown cell with the first line as an H1 title."""
+    with open(nb_path) as f:
+        nb = json.load(f)
+
+    cells = nb.get("cells", [])
+    if not cells:
+        return
+
+    first = cells[0]
+    if first["cell_type"] != "code":
+        return
+
+    source = "".join(first["source"]) if isinstance(first["source"], list) else first["source"]
+    stripped = source.strip()
+
+    # Check for triple-quoted docstring as the sole content
+    for quote in ('"""', "'''"):
+        if stripped.startswith(quote) and stripped.endswith(quote) and stripped.count(quote) == 2:
+            body = stripped[3:-3].strip()
+            break
+    else:
+        return
+
+    # Split into title (first line) and description (rest)
+    lines = body.split("\n", 1)
+    title = lines[0].strip()
+    description = lines[1].strip() if len(lines) > 1 else ""
+
+    md_source = f"# {title}"
+    if description:
+        md_source += f"\n\n{description}"
+
+    first["cell_type"] = "markdown"
+    first["source"] = md_source
+    # Remove code-cell-only keys
+    first.pop("execution_count", None)
+    first.pop("outputs", None)
+
+    with open(nb_path, "w") as f:
+        json.dump(nb, f, indent=1)
+        f.write("\n")
+
+
+def main() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    py_files = sorted(EXAMPLES_DIR.glob("*.py"))
+    if not py_files:
+        print("No example .py files found.", file=sys.stderr)
+        sys.exit(1)
+
+    for py_file in py_files:
+        out_file = OUTPUT_DIR / py_file.with_suffix(".ipynb").name
+        print(f"  {py_file.name} -> {out_file.relative_to(REPO_ROOT)}")
+        subprocess.check_call(
+            [sys.executable, "-m", "jupytext", "--to", "notebook", str(py_file), "-o", str(out_file)],
+        )
+        _promote_docstring_to_markdown(out_file)
+
+    print(f"Converted {len(py_files)} examples to {OUTPUT_DIR.relative_to(REPO_ROOT)}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,8 @@ k-Wave is an open source acoustics toolbox for MATLAB and C++ developed by Bradl
    get_started/source_overview
    get_started/sensor_overview
    get_started/examples_guide
+   examples
+
 .. toctree::
    :caption: k-Wave-python API
    :titlesonly:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,9 @@ docs = [ "sphinx-mdinclude==0.6.2",
     "sphinx-copybutton==0.5.2",
     "sphinx-tabs==3.4.7",
     "sphinx-toolbox==3.8.0",
-    "furo==2024.8.6"]
+    "furo==2024.8.6",
+    "nbsphinx==0.9.7",
+    "jupytext==1.16.6"]
 dev = ["pre-commit==4.5.1"]
 
 [tool.hatch.version]

--- a/tests/test_example_parity.py
+++ b/tests/test_example_parity.py
@@ -5,7 +5,7 @@ kgrid, medium, source), adds a **full-grid binary sensor**, and compares against
 MATLAB reference data generated with the same binary sensor.
 
 Binary sensors give machine-precision parity (<1e-13 relative).  The examples'
-own ``run()`` functions may use Cartesian or sparse sensors for teaching — those
+own ``run()`` functions may use Cartesian or sparse sensors for teaching --- those
 are not tested here.
 
 MATLAB references are per-example v7 .mat files in the sibling k-wave-cupy repo.
@@ -117,20 +117,23 @@ def _pml_crop(ndim):
 
 # (name, ndim, p_thresh, p_final_thresh)
 _EXAMPLES = [
-    # IVP — machine precision for both p and p_final
+    # IVP --- machine precision for both p and p_final
     ("ivp_homogeneous_medium", 2, THRESH, THRESH),
     ("ivp_heterogeneous_medium", 2, THRESH, THRESH),
     ("ivp_binary_sensor_mask", 2, THRESH, THRESH),
     ("ivp_1D_simulation", 1, THRESH, THRESH),
     ("ivp_loading_external_image", 2, THRESH, THRESH),
     ("ivp_photoacoustic_waveforms", 2, THRESH, THRESH),
-    # TVSP — p is machine precision, p_final is looser (more FFT round-trips)
+    # ivp_saving_movie_files: heterogeneous sound_speed + density with makeDisc.
+    # ~1.5% p error due to makeDisc/smooth differences; p_final is tighter.
+    ("ivp_saving_movie_files", 2, 2e-2, 2e-2),
+    # TVSP --- p is machine precision, p_final is looser (more FFT round-trips)
     ("tvsp_homogeneous_medium_monopole", 2, THRESH, THRESH_TVSP),
     ("tvsp_homogeneous_medium_dipole", 2, THRESH, THRESH_TVSP),
     ("tvsp_steering_linear_array", 2, THRESH, THRESH_TVSP),
     ("tvsp_snells_law", 2, THRESH, THRESH_TVSP),
     ("tvsp_doppler_effect", 2, THRESH_TVSP, THRESH_TVSP),
-    # NA (filtering) — p is machine precision, p_final looser for parts 2/3
+    # NA (filtering) --- p is machine precision, p_final looser for parts 2/3
     ("na_filtering_part_1", 1, THRESH, THRESH),
     ("na_filtering_part_2", 1, THRESH, THRESH_TVSP),
     ("na_filtering_part_3", 1, THRESH, THRESH_TVSP),
@@ -226,7 +229,7 @@ class TestNAControllingPML:
 
     def test_p_final(self, scenario):
         result, ref, shape = scenario
-        # pml_alpha=0 means no absorption at boundary — full field valid, no PML crop
+        # pml_alpha=0 means no absorption at boundary --- full field valid, no PML crop
         _assert_close(np.asarray(result["p_final"]), ref["p_final"], "p_final")
 
 
@@ -244,11 +247,11 @@ class TestNAModellingNonlinearity:
 
 
 # ---------------------------------------------------------------------------
-# 3D examples — skipped pending investigation
+# 3D examples --- skipped pending investigation
 # ---------------------------------------------------------------------------
 
 _SKIPPED_3D = [
-    # TODO: investigate 3D p_final mismatch — Python max 7e-5 at (20,20,24) vs
+    # TODO: investigate 3D p_final mismatch --- Python max 7e-5 at (20,20,24) vs
     # MATLAB max 2e-4 at (60,53,19). Not an axis permutation (all 6 tried).
     # Likely a difference in p0 smoothing or heterogeneous medium setup for 3D.
     ("ivp_3D_simulation", 3, THRESH, ["p_final"]),
@@ -257,7 +260,7 @@ _SKIPPED_3D = [
 
 
 @pytest.mark.matlab_parity
-@pytest.mark.skip(reason="3D p_final axis ordering mismatch — needs investigation")
+@pytest.mark.skip(reason="3D p_final axis ordering mismatch --- needs investigation")
 class TestSkipped3D:
     @pytest.fixture(scope="class", params=_SKIPPED_3D, ids=[e[0] for e in _SKIPPED_3D])
     def scenario(self, request):
@@ -274,17 +277,276 @@ class TestSkipped3D:
 
 
 # ---------------------------------------------------------------------------
-# TODO: Parity tests still needed for these ported examples:
-#
-# - ivp_saving_movie_files (standard 2D IVP — straightforward)
-# - na_optimising_performance (uses Cartesian sensor — needs custom ref)
-# - na_source_smoothing (uses kspaceFirstOrder not kspaceSecondOrder)
-# - pr_2D_FFT_line_sensor (forward sim with pml_inside=False)
-# - pr_3D_FFT_planar_sensor (forward sim, pml_inside deviation)
-# - sd_directional_array_elements (multi-element averaging — custom harness)
-# - sd_directivity_modelling_2D (11 sims — custom harness)
-# - sd_directivity_modelling_3D (11 sims on 64^3 — slow, custom harness)
-#
-# The SD directivity examples need a different test pattern: call run()
-# directly (not _run_with_binary_sensor) and compare element-level output.
+# Custom-run: na_optimising_performance (Cartesian sensor, calls run())
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+class TestNAOptimisingPerformance:
+    """Ref uses Cartesian circular sensor (100 points).  Cartesian p data
+    involves Delaunay interpolation that differs between MATLAB and Python,
+    so we only compare p_final (full-grid, no interpolation)."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        from examples.na_optimising_performance import run
+
+        ref = _load_ref("na_optimising_performance")
+        return run(), ref
+
+    def test_p_final(self, scenario):
+        result, ref = scenario
+        _assert_close(
+            np.asarray(result["p_final"]),
+            ref["p_final"][_pml_crop(2)],
+            "p_final",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Custom-run: na_source_smoothing (3 windows, 1D)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+class TestNASourceSmoothing:
+    """Three 1D simulations (no window, Hanning, Blackman).
+    MATLAB ref uses full-grid binary sensor, so we re-run each case with
+    a binary sensor (the example's run() uses a single-point sensor)."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        from examples.na_source_smoothing import _apply_window, setup
+
+        ref = _load_ref("na_source_smoothing")
+        Nx = 256
+
+        results = {}
+        for label, window_type in [
+            ("no_window", None),
+            ("hanning", "Hanning"),
+            ("blackman", "Blackman"),
+        ]:
+            kgrid, medium, source = setup()
+            if window_type is not None:
+                source.p0 = _apply_window(source.p0, Nx, window_type)
+            sensor = kSensor(mask=np.ones(Nx, dtype=bool))
+            sensor.record = ["p", "p_final"]
+            results[label] = kspaceFirstOrder(
+                kgrid,
+                medium,
+                source,
+                sensor,
+                backend="python",
+                quiet=True,
+                pml_inside=True,
+                smooth_p0=False,
+            )
+
+        return results, ref
+
+    @pytest.mark.parametrize("label", ["no_window", "hanning", "blackman"])
+    def test_p(self, scenario, label):
+        results, ref = scenario
+        py_p = np.asarray(results[label]["p"])
+        mat_p = ref[f"p_{label}"]
+        _assert_close(py_p, mat_p, f"p_{label}", thresh=THRESH_TVSP)
+
+    @pytest.mark.parametrize("label", ["no_window", "hanning", "blackman"])
+    def test_p_final(self, scenario, label):
+        results, ref = scenario
+        py_pf = np.asarray(results[label]["p_final"])
+        mat_pf = ref[f"p_final_{label}"]
+        mat_pf = mat_pf[_pml_crop(1)]
+        _assert_close(py_pf, mat_pf, f"p_final_{label}", thresh=THRESH_TVSP)
+
+
+# ---------------------------------------------------------------------------
+# Custom-run: pr_2D_FFT_line_sensor (pml_inside=False, full-grid sensor)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+class TestPR2DFFTLineSensor:
+    """Forward sim with pml_inside=False on 88x216 grid.
+    MATLAB ref uses full-grid binary sensor with PMLInside=false, so we
+    replicate that: setup() gives the 88x216 grid, we add a full-grid
+    binary sensor and run with pml_inside=False."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        from examples.pr_2D_FFT_line_sensor import setup
+
+        kgrid, medium, source = setup()
+        Nx, Ny = 88, 216
+        sensor = kSensor(mask=np.ones((Nx, Ny), dtype=bool))
+        sensor.record = ["p", "p_final"]
+        result = kspaceFirstOrder(
+            kgrid,
+            medium,
+            source,
+            sensor,
+            backend="python",
+            quiet=True,
+            pml_inside=False,
+            pml_size=20,
+            smooth_p0=False,
+        )
+
+        ref = _load_ref("pr_2D_FFT_line_sensor")
+        grid_shape = (int(ref["Nx"]), int(ref["Ny"]))
+        return result, ref, grid_shape
+
+    def test_p(self, scenario):
+        result, ref, grid_shape = scenario
+        matlab_p = _reorder_fullgrid(ref["p"], grid_shape)
+        _assert_close(np.asarray(result["p"]), matlab_p, "p")
+
+    def test_p_final(self, scenario):
+        result, ref, _grid_shape = scenario
+        _assert_close(np.asarray(result["p_final"]), ref["p_final"], "p_final")
+
+
+# ---------------------------------------------------------------------------
+# Custom-run: pr_3D_FFT_planar_sensor (pml_inside=False, blocked by validation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+@pytest.mark.skip(
+    reason="MATLAB ref uses pml_inside=False on 12x44x44 grid; "
+    "Python validation rejects pml_size=10 when Nx=12 (2*pml >= N). "
+    "Needs relaxed pml_inside=False validation."
+)
+class TestPR3DFFTPlanarSensor:
+    """Forward 3D sim. MATLAB ref uses pml_inside=False on 12x44x44 grid
+    (ball centred on 12x44x44). Python validation currently rejects this
+    because 2*pml_size >= Nx. Test will be enabled once the validation
+    is relaxed for pml_inside=False."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        from kwave.data import Vector
+        from kwave.kgrid import kWaveGrid
+        from kwave.kmedium import kWaveMedium
+        from kwave.ksource import kSource
+        from kwave.utils.filters import smooth
+        from kwave.utils.mapgen import make_ball
+
+        pml_size = 10
+        Nx, Ny, Nz = 12, 44, 44
+        dx = dy = dz = 0.2e-3
+        kgrid = kWaveGrid(Vector([Nx, Ny, Nz]), Vector([dx, dy, dz]))
+        medium = kWaveMedium(sound_speed=1500)
+
+        ball_magnitude = 10
+        ball_radius = 3
+        p0 = ball_magnitude * make_ball(
+            Vector([Nx, Ny, Nz]),
+            Vector([Nx // 2, Ny // 2, Nz // 2]),
+            ball_radius,
+        )
+        source = kSource()
+        source.p0 = smooth(p0.astype(float), restore_max=True)
+        kgrid.makeTime(medium.sound_speed)
+
+        sensor = kSensor(mask=np.ones((Nx, Ny, Nz), dtype=bool))
+        sensor.record = ["p", "p_final"]
+        result = kspaceFirstOrder(
+            kgrid,
+            medium,
+            source,
+            sensor,
+            backend="python",
+            quiet=True,
+            pml_inside=False,
+            pml_size=pml_size,
+            smooth_p0=False,
+        )
+        ref = _load_ref("pr_3D_FFT_planar_sensor")
+        grid_shape = (int(ref["Nx"]), int(ref["Ny"]), int(ref["Nz"]))
+        return result, ref, grid_shape
+
+    def test_p(self, scenario):
+        result, ref, grid_shape = scenario
+        matlab_p = _reorder_fullgrid(ref["p"], grid_shape)
+        _assert_close(np.asarray(result["p"]), matlab_p, "p")
+
+    def test_p_final(self, scenario):
+        result, ref, _grid_shape = scenario
+        _assert_close(np.asarray(result["p_final"]), ref["p_final"], "p_final")
+
+
+# ---------------------------------------------------------------------------
+# Custom-run: sd_directional_array_elements (13 elements, calls run())
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+class TestSDDirectionalArrayElements:
+    """13-element semicircular array with per-element averaging."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        from examples.sd_directional_array_elements import run
+
+        ref = _load_ref("sd_directional_array_elements")
+        return run(), ref
+
+    def test_element_data(self, scenario):
+        result, ref = scenario
+        _assert_close(
+            np.asarray(result["element_data"]),
+            ref["element_data"],
+            "element_data",
+            thresh=THRESH_TVSP,
+        )
+
+
+# ---------------------------------------------------------------------------
+# SD directivity modelling 2D/3D -- no MATLAB references yet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+class TestSDDirectivityModelling2D:
+    """11 sims with point sources on semicircle, 2D.
+    Skipped until MATLAB reference is generated."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        ref = _load_ref("sd_directivity_modelling_2D")  # will pytest.skip
+        from examples.sd_directivity_modelling_2D import run
+
+        return run(), ref
+
+    def test_single_element_data(self, scenario):
+        result, ref = scenario
+        _assert_close(
+            np.asarray(result["single_element_data"]),
+            ref["single_element_data"],
+            "single_element_data",
+            thresh=THRESH_TVSP,
+        )
+
+
+@pytest.mark.matlab_parity
+class TestSDDirectivityModelling3D:
+    """11 sims on 64^3 grid with point sources on semicircle, 3D.
+    Skipped until MATLAB reference is generated. Slow (~minutes)."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        ref = _load_ref("sd_directivity_modelling_3D")  # will pytest.skip
+        from examples.sd_directivity_modelling_3D import run
+
+        return run(), ref
+
+    def test_single_element_data(self, scenario):
+        result, ref = scenario
+        _assert_close(
+            np.asarray(result["single_element_data"]),
+            ref["single_element_data"],
+            "single_element_data",
+            thresh=THRESH_TVSP,
+        )

--- a/tests/test_example_parity.py
+++ b/tests/test_example_parity.py
@@ -5,7 +5,7 @@ kgrid, medium, source), adds a **full-grid binary sensor**, and compares against
 MATLAB reference data generated with the same binary sensor.
 
 Binary sensors give machine-precision parity (<1e-13 relative).  The examples'
-own ``run()`` functions may use Cartesian or sparse sensors for teaching --- those
+own ``run()`` functions may use Cartesian or sparse sensors for teaching — those
 are not tested here.
 
 MATLAB references are per-example v7 .mat files in the sibling k-wave-cupy repo.
@@ -117,23 +117,20 @@ def _pml_crop(ndim):
 
 # (name, ndim, p_thresh, p_final_thresh)
 _EXAMPLES = [
-    # IVP --- machine precision for both p and p_final
+    # IVP — machine precision for both p and p_final
     ("ivp_homogeneous_medium", 2, THRESH, THRESH),
     ("ivp_heterogeneous_medium", 2, THRESH, THRESH),
     ("ivp_binary_sensor_mask", 2, THRESH, THRESH),
     ("ivp_1D_simulation", 1, THRESH, THRESH),
     ("ivp_loading_external_image", 2, THRESH, THRESH),
     ("ivp_photoacoustic_waveforms", 2, THRESH, THRESH),
-    # ivp_saving_movie_files: heterogeneous sound_speed + density with makeDisc.
-    # ~1.5% p error due to makeDisc/smooth differences; p_final is tighter.
-    ("ivp_saving_movie_files", 2, 2e-2, 2e-2),
-    # TVSP --- p is machine precision, p_final is looser (more FFT round-trips)
+    # TVSP — p is machine precision, p_final is looser (more FFT round-trips)
     ("tvsp_homogeneous_medium_monopole", 2, THRESH, THRESH_TVSP),
     ("tvsp_homogeneous_medium_dipole", 2, THRESH, THRESH_TVSP),
     ("tvsp_steering_linear_array", 2, THRESH, THRESH_TVSP),
     ("tvsp_snells_law", 2, THRESH, THRESH_TVSP),
     ("tvsp_doppler_effect", 2, THRESH_TVSP, THRESH_TVSP),
-    # NA (filtering) --- p is machine precision, p_final looser for parts 2/3
+    # NA (filtering) — p is machine precision, p_final looser for parts 2/3
     ("na_filtering_part_1", 1, THRESH, THRESH),
     ("na_filtering_part_2", 1, THRESH, THRESH_TVSP),
     ("na_filtering_part_3", 1, THRESH, THRESH_TVSP),
@@ -229,7 +226,7 @@ class TestNAControllingPML:
 
     def test_p_final(self, scenario):
         result, ref, shape = scenario
-        # pml_alpha=0 means no absorption at boundary --- full field valid, no PML crop
+        # pml_alpha=0 means no absorption at boundary — full field valid, no PML crop
         _assert_close(np.asarray(result["p_final"]), ref["p_final"], "p_final")
 
 
@@ -247,11 +244,11 @@ class TestNAModellingNonlinearity:
 
 
 # ---------------------------------------------------------------------------
-# 3D examples --- skipped pending investigation
+# 3D examples — skipped pending investigation
 # ---------------------------------------------------------------------------
 
 _SKIPPED_3D = [
-    # TODO: investigate 3D p_final mismatch --- Python max 7e-5 at (20,20,24) vs
+    # TODO: investigate 3D p_final mismatch — Python max 7e-5 at (20,20,24) vs
     # MATLAB max 2e-4 at (60,53,19). Not an axis permutation (all 6 tried).
     # Likely a difference in p0 smoothing or heterogeneous medium setup for 3D.
     ("ivp_3D_simulation", 3, THRESH, ["p_final"]),
@@ -260,7 +257,7 @@ _SKIPPED_3D = [
 
 
 @pytest.mark.matlab_parity
-@pytest.mark.skip(reason="3D p_final axis ordering mismatch --- needs investigation")
+@pytest.mark.skip(reason="3D p_final axis ordering mismatch — needs investigation")
 class TestSkipped3D:
     @pytest.fixture(scope="class", params=_SKIPPED_3D, ids=[e[0] for e in _SKIPPED_3D])
     def scenario(self, request):
@@ -277,276 +274,17 @@ class TestSkipped3D:
 
 
 # ---------------------------------------------------------------------------
-# Custom-run: na_optimising_performance (Cartesian sensor, calls run())
+# TODO: Parity tests still needed for these ported examples:
+#
+# - ivp_saving_movie_files (standard 2D IVP — straightforward)
+# - na_optimising_performance (uses Cartesian sensor — needs custom ref)
+# - na_source_smoothing (uses kspaceFirstOrder not kspaceSecondOrder)
+# - pr_2D_FFT_line_sensor (forward sim with pml_inside=False)
+# - pr_3D_FFT_planar_sensor (forward sim, pml_inside deviation)
+# - sd_directional_array_elements (multi-element averaging — custom harness)
+# - sd_directivity_modelling_2D (11 sims — custom harness)
+# - sd_directivity_modelling_3D (11 sims on 64^3 — slow, custom harness)
+#
+# The SD directivity examples need a different test pattern: call run()
+# directly (not _run_with_binary_sensor) and compare element-level output.
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.matlab_parity
-class TestNAOptimisingPerformance:
-    """Ref uses Cartesian circular sensor (100 points).  Cartesian p data
-    involves Delaunay interpolation that differs between MATLAB and Python,
-    so we only compare p_final (full-grid, no interpolation)."""
-
-    @pytest.fixture(scope="class")
-    def scenario(self):
-        from examples.na_optimising_performance import run
-
-        ref = _load_ref("na_optimising_performance")
-        return run(), ref
-
-    def test_p_final(self, scenario):
-        result, ref = scenario
-        _assert_close(
-            np.asarray(result["p_final"]),
-            ref["p_final"][_pml_crop(2)],
-            "p_final",
-        )
-
-
-# ---------------------------------------------------------------------------
-# Custom-run: na_source_smoothing (3 windows, 1D)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.matlab_parity
-class TestNASourceSmoothing:
-    """Three 1D simulations (no window, Hanning, Blackman).
-    MATLAB ref uses full-grid binary sensor, so we re-run each case with
-    a binary sensor (the example's run() uses a single-point sensor)."""
-
-    @pytest.fixture(scope="class")
-    def scenario(self):
-        from examples.na_source_smoothing import _apply_window, setup
-
-        ref = _load_ref("na_source_smoothing")
-        Nx = 256
-
-        results = {}
-        for label, window_type in [
-            ("no_window", None),
-            ("hanning", "Hanning"),
-            ("blackman", "Blackman"),
-        ]:
-            kgrid, medium, source = setup()
-            if window_type is not None:
-                source.p0 = _apply_window(source.p0, Nx, window_type)
-            sensor = kSensor(mask=np.ones(Nx, dtype=bool))
-            sensor.record = ["p", "p_final"]
-            results[label] = kspaceFirstOrder(
-                kgrid,
-                medium,
-                source,
-                sensor,
-                backend="python",
-                quiet=True,
-                pml_inside=True,
-                smooth_p0=False,
-            )
-
-        return results, ref
-
-    @pytest.mark.parametrize("label", ["no_window", "hanning", "blackman"])
-    def test_p(self, scenario, label):
-        results, ref = scenario
-        py_p = np.asarray(results[label]["p"])
-        mat_p = ref[f"p_{label}"]
-        _assert_close(py_p, mat_p, f"p_{label}", thresh=THRESH_TVSP)
-
-    @pytest.mark.parametrize("label", ["no_window", "hanning", "blackman"])
-    def test_p_final(self, scenario, label):
-        results, ref = scenario
-        py_pf = np.asarray(results[label]["p_final"])
-        mat_pf = ref[f"p_final_{label}"]
-        mat_pf = mat_pf[_pml_crop(1)]
-        _assert_close(py_pf, mat_pf, f"p_final_{label}", thresh=THRESH_TVSP)
-
-
-# ---------------------------------------------------------------------------
-# Custom-run: pr_2D_FFT_line_sensor (pml_inside=False, full-grid sensor)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.matlab_parity
-class TestPR2DFFTLineSensor:
-    """Forward sim with pml_inside=False on 88x216 grid.
-    MATLAB ref uses full-grid binary sensor with PMLInside=false, so we
-    replicate that: setup() gives the 88x216 grid, we add a full-grid
-    binary sensor and run with pml_inside=False."""
-
-    @pytest.fixture(scope="class")
-    def scenario(self):
-        from examples.pr_2D_FFT_line_sensor import setup
-
-        kgrid, medium, source = setup()
-        Nx, Ny = 88, 216
-        sensor = kSensor(mask=np.ones((Nx, Ny), dtype=bool))
-        sensor.record = ["p", "p_final"]
-        result = kspaceFirstOrder(
-            kgrid,
-            medium,
-            source,
-            sensor,
-            backend="python",
-            quiet=True,
-            pml_inside=False,
-            pml_size=20,
-            smooth_p0=False,
-        )
-
-        ref = _load_ref("pr_2D_FFT_line_sensor")
-        grid_shape = (int(ref["Nx"]), int(ref["Ny"]))
-        return result, ref, grid_shape
-
-    def test_p(self, scenario):
-        result, ref, grid_shape = scenario
-        matlab_p = _reorder_fullgrid(ref["p"], grid_shape)
-        _assert_close(np.asarray(result["p"]), matlab_p, "p")
-
-    def test_p_final(self, scenario):
-        result, ref, _grid_shape = scenario
-        _assert_close(np.asarray(result["p_final"]), ref["p_final"], "p_final")
-
-
-# ---------------------------------------------------------------------------
-# Custom-run: pr_3D_FFT_planar_sensor (pml_inside=False, blocked by validation)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.matlab_parity
-@pytest.mark.skip(
-    reason="MATLAB ref uses pml_inside=False on 12x44x44 grid; "
-    "Python validation rejects pml_size=10 when Nx=12 (2*pml >= N). "
-    "Needs relaxed pml_inside=False validation."
-)
-class TestPR3DFFTPlanarSensor:
-    """Forward 3D sim. MATLAB ref uses pml_inside=False on 12x44x44 grid
-    (ball centred on 12x44x44). Python validation currently rejects this
-    because 2*pml_size >= Nx. Test will be enabled once the validation
-    is relaxed for pml_inside=False."""
-
-    @pytest.fixture(scope="class")
-    def scenario(self):
-        from kwave.data import Vector
-        from kwave.kgrid import kWaveGrid
-        from kwave.kmedium import kWaveMedium
-        from kwave.ksource import kSource
-        from kwave.utils.filters import smooth
-        from kwave.utils.mapgen import make_ball
-
-        pml_size = 10
-        Nx, Ny, Nz = 12, 44, 44
-        dx = dy = dz = 0.2e-3
-        kgrid = kWaveGrid(Vector([Nx, Ny, Nz]), Vector([dx, dy, dz]))
-        medium = kWaveMedium(sound_speed=1500)
-
-        ball_magnitude = 10
-        ball_radius = 3
-        p0 = ball_magnitude * make_ball(
-            Vector([Nx, Ny, Nz]),
-            Vector([Nx // 2, Ny // 2, Nz // 2]),
-            ball_radius,
-        )
-        source = kSource()
-        source.p0 = smooth(p0.astype(float), restore_max=True)
-        kgrid.makeTime(medium.sound_speed)
-
-        sensor = kSensor(mask=np.ones((Nx, Ny, Nz), dtype=bool))
-        sensor.record = ["p", "p_final"]
-        result = kspaceFirstOrder(
-            kgrid,
-            medium,
-            source,
-            sensor,
-            backend="python",
-            quiet=True,
-            pml_inside=False,
-            pml_size=pml_size,
-            smooth_p0=False,
-        )
-        ref = _load_ref("pr_3D_FFT_planar_sensor")
-        grid_shape = (int(ref["Nx"]), int(ref["Ny"]), int(ref["Nz"]))
-        return result, ref, grid_shape
-
-    def test_p(self, scenario):
-        result, ref, grid_shape = scenario
-        matlab_p = _reorder_fullgrid(ref["p"], grid_shape)
-        _assert_close(np.asarray(result["p"]), matlab_p, "p")
-
-    def test_p_final(self, scenario):
-        result, ref, _grid_shape = scenario
-        _assert_close(np.asarray(result["p_final"]), ref["p_final"], "p_final")
-
-
-# ---------------------------------------------------------------------------
-# Custom-run: sd_directional_array_elements (13 elements, calls run())
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.matlab_parity
-class TestSDDirectionalArrayElements:
-    """13-element semicircular array with per-element averaging."""
-
-    @pytest.fixture(scope="class")
-    def scenario(self):
-        from examples.sd_directional_array_elements import run
-
-        ref = _load_ref("sd_directional_array_elements")
-        return run(), ref
-
-    def test_element_data(self, scenario):
-        result, ref = scenario
-        _assert_close(
-            np.asarray(result["element_data"]),
-            ref["element_data"],
-            "element_data",
-            thresh=THRESH_TVSP,
-        )
-
-
-# ---------------------------------------------------------------------------
-# SD directivity modelling 2D/3D -- no MATLAB references yet
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.matlab_parity
-class TestSDDirectivityModelling2D:
-    """11 sims with point sources on semicircle, 2D.
-    Skipped until MATLAB reference is generated."""
-
-    @pytest.fixture(scope="class")
-    def scenario(self):
-        ref = _load_ref("sd_directivity_modelling_2D")  # will pytest.skip
-        from examples.sd_directivity_modelling_2D import run
-
-        return run(), ref
-
-    def test_single_element_data(self, scenario):
-        result, ref = scenario
-        _assert_close(
-            np.asarray(result["single_element_data"]),
-            ref["single_element_data"],
-            "single_element_data",
-            thresh=THRESH_TVSP,
-        )
-
-
-@pytest.mark.matlab_parity
-class TestSDDirectivityModelling3D:
-    """11 sims on 64^3 grid with point sources on semicircle, 3D.
-    Skipped until MATLAB reference is generated. Slow (~minutes)."""
-
-    @pytest.fixture(scope="class")
-    def scenario(self):
-        ref = _load_ref("sd_directivity_modelling_3D")  # will pytest.skip
-        from examples.sd_directivity_modelling_3D import run
-
-        return run(), ref
-
-    def test_single_element_data(self, scenario):
-        result, ref = scenario
-        _assert_close(
-            np.asarray(result["single_element_data"]),
-            ref["single_element_data"],
-            "single_element_data",
-            thresh=THRESH_TVSP,
-        )


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an example notebook gallery for the k-wave-python documentation: it adds a `generate_example_notebooks.py` script that converts `examples/*.py` files (jupytext percent format) to `.ipynb` notebooks in `docs/_examples/`, hooks that generation into both the `docs/Makefile` and the CI workflow, and a new `examples.rst` toctree page that exposes all 29 example notebooks via nbsphinx.

**Key changes:**
- `docs/generate_example_notebooks.py` — new script that shells out to `jupytext`, then promotes standalone module docstrings into rendered Markdown H1 cells.
- `.github/workflows/test_pages.yml` — adds pandoc install, manual `pip install '.[docs]'`, and notebook generation *before* the `waltsims/pages` action runs (fixing the previous double-installation issue by removing `pyproject_toml_deps` from the action's `with:` block).
- `docs/conf.py` — enables the `nbsphinx` extension with `nbsphinx_execute = "never"` (pre-rendered) and a Colab badge prolog; the badge URL still points to a `notebooks/` path that does not exist in the repository (noted in a prior review).
- `docs/_examples/` is gitignored, so notebooks are regenerated on every CI run rather than committed.
- `pyproject.toml` adds `nbsphinx==0.9.7` and `jupytext==1.16.6` to the `docs` dependency group.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are minor style/edge-case suggestions that do not affect runtime behaviour.

No new P0 or P1 issues were found. The two P2 comments (.PHONY declaration and empty-docstring edge case) are non-blocking. The previously flagged Colab badge URL problem and double-installation concern are pre-existing and already in discussion; this PR does not worsen them and in fact fixes the double-installation by removing pyproject_toml_deps from the action.

docs/conf.py for the unresolved Colab badge path (tracked in a prior review thread).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/test_pages.yml | Adds pandoc install, explicit dep install, and notebook generation before the pages action; removes the `pyproject_toml_deps` parameter from the action — intentional to avoid double-installation. |
| docs/generate_example_notebooks.py | New script converting `examples/*.py` (jupytext percent format) to `.ipynb` files in `docs/_examples/`; docstring-to-markdown promotion logic is mostly correct but has a minor empty-docstring edge case. |
| docs/conf.py | Adds `nbsphinx` extension and Colab badge prolog; Colab URL still references `master/notebooks/` which doesn't exist in the repo (flagged in prior review). |
| docs/Makefile | Adds a `notebooks` target for jupytext conversion and overrides `html` to depend on it; `html` should be declared `.PHONY`. |
| docs/examples.rst | New file listing all 29 example notebooks in a toctree gallery; all referenced filenames match the actual `examples/*.py` files. |
| .gitignore | Adds `docs/_examples/` to .gitignore so generated notebooks aren't committed; intentional since they're regenerated in CI. |
| pyproject.toml | Adds `nbsphinx==0.9.7` and `jupytext==1.16.6` to the `docs` optional-dependency group. |
| docs/index.rst | Adds `examples` to the toctree so the new gallery page is linked from the main navigation. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI: checkout repo] --> B[Install pandoc]
    B --> C["pip install '.[docs]'\n(nbsphinx, jupytext, sphinx…)"]
    C --> D[python docs/generate_example_notebooks.py]
    D --> E["For each examples/*.py\njupytext --to notebook → docs/_examples/*.ipynb"]
    E --> F[_promote_docstring_to_markdown\nconvert first code cell → Markdown H1]
    F --> G[waltsims/pages action]
    G --> H[sphinx-build reads docs/examples.rst toctrees]
    H --> I[nbsphinx renders _examples/*.ipynb]
    I --> J[Colab badge prepended via nbsphinx_prolog]
    J --> K[Commit built docs to gh-pages branch]
```

<sub>Reviews (2): Last reviewed commit: ["Fix Colab badge URLs and remove double d..."](https://github.com/waltsims/k-wave-python/commit/999ae4d8b02ee05d99f2b76c43c64a4327124f4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26697931)</sub>

<!-- /greptile_comment -->