### PR TITLE
Add parity tests for 8 remaining ported examples

### DIFF
--- a/tests/test_example_parity.py
+++ b/tests/test_example_parity.py
@@ -5,7 +5,7 @@ kgrid, medium, source), adds a **full-grid binary sensor**, and compares against
 MATLAB reference data generated with the same binary sensor.
 
 Binary sensors give machine-precision parity (<1e-13 relative).  The examples'
-own ``run()`` functions may use Cartesian or sparse sensors for teaching — those
+own ``run()`` functions may use Cartesian or sparse sensors for teaching --- those
 are not tested here.
 
 MATLAB references are per-example v7 .mat files in the sibling k-wave-cupy repo.
@@ -117,20 +117,23 @@ def _pml_crop(ndim):
 
 # (name, ndim, p_thresh, p_final_thresh)
 _EXAMPLES = [
-    # IVP — machine precision for both p and p_final
+    # IVP --- machine precision for both p and p_final
     ("ivp_homogeneous_medium", 2, THRESH, THRESH),
     ("ivp_heterogeneous_medium", 2, THRESH, THRESH),
     ("ivp_binary_sensor_mask", 2, THRESH, THRESH),
     ("ivp_1D_simulation", 1, THRESH, THRESH),
     ("ivp_loading_external_image", 2, THRESH, THRESH),
     ("ivp_photoacoustic_waveforms", 2, THRESH, THRESH),
-    # TVSP — p is machine precision, p_final is looser (more FFT round-trips)
+    # ivp_saving_movie_files: heterogeneous sound_speed + density with makeDisc.
+    # ~1.5% p error due to makeDisc/smooth differences; p_final is tighter.
+    ("ivp_saving_movie_files", 2, 2e-2, 2e-2),
+    # TVSP --- p is machine precision, p_final is looser (more FFT round-trips)
     ("tvsp_homogeneous_medium_monopole", 2, THRESH, THRESH_TVSP),
     ("tvsp_homogeneous_medium_dipole", 2, THRESH, THRESH_TVSP),
     ("tvsp_steering_linear_array", 2, THRESH, THRESH_TVSP),
     ("tvsp_snells_law", 2, THRESH, THRESH_TVSP),
     ("tvsp_doppler_effect", 2, THRESH_TVSP, THRESH_TVSP),
-    # NA (filtering) — p is machine precision, p_final looser for parts 2/3
+    # NA (filtering) --- p is machine precision, p_final looser for parts 2/3
     ("na_filtering_part_1", 1, THRESH, THRESH),
     ("na_filtering_part_2", 1, THRESH, THRESH_TVSP),
     ("na_filtering_part_3", 1, THRESH, THRESH_TVSP),
@@ -226,7 +229,7 @@ class TestNAControllingPML:
 
     def test_p_final(self, scenario):
         result, ref, shape = scenario
-        # pml_alpha=0 means no absorption at boundary — full field valid, no PML crop
+        # pml_alpha=0 means no absorption at boundary --- full field valid, no PML crop
         _assert_close(np.asarray(result["p_final"]), ref["p_final"], "p_final")
 
 
@@ -244,11 +247,11 @@ class TestNAModellingNonlinearity:
 
 
 # ---------------------------------------------------------------------------
-# 3D examples — skipped pending investigation
+# 3D examples --- skipped pending investigation
 # ---------------------------------------------------------------------------
 
 _SKIPPED_3D = [
-    # TODO: investigate 3D p_final mismatch — Python max 7e-5 at (20,20,24) vs
+    # TODO: investigate 3D p_final mismatch --- Python max 7e-5 at (20,20,24) vs
     # MATLAB max 2e-4 at (60,53,19). Not an axis permutation (all 6 tried).
     # Likely a difference in p0 smoothing or heterogeneous medium setup for 3D.
     ("ivp_3D_simulation", 3, THRESH, ["p_final"]),
@@ -257,7 +260,7 @@ _SKIPPED_3D = [
 
 
 @pytest.mark.matlab_parity
-@pytest.mark.skip(reason="3D p_final axis ordering mismatch — needs investigation")
+@pytest.mark.skip(reason="3D p_final axis ordering mismatch --- needs investigation")
 class TestSkipped3D:
     @pytest.fixture(scope="class", params=_SKIPPED_3D, ids=[e[0] for e in _SKIPPED_3D])
     def scenario(self, request):
@@ -274,17 +277,276 @@ class TestSkipped3D:
 
 
 # ---------------------------------------------------------------------------
-# TODO: Parity tests still needed for these ported examples:
-#
-# - ivp_saving_movie_files (standard 2D IVP — straightforward)
-# - na_optimising_performance (uses Cartesian sensor — needs custom ref)
-# - na_source_smoothing (uses kspaceFirstOrder not kspaceSecondOrder)
-# - pr_2D_FFT_line_sensor (forward sim with pml_inside=False)
-# - pr_3D_FFT_planar_sensor (forward sim, pml_inside deviation)
-# - sd_directional_array_elements (multi-element averaging — custom harness)
-# - sd_directivity_modelling_2D (11 sims — custom harness)
-# - sd_directivity_modelling_3D (11 sims on 64^3 — slow, custom harness)
-#
-# The SD directivity examples need a different test pattern: call run()
-# directly (not _run_with_binary_sensor) and compare element-level output.
+# Custom-run: na_optimising_performance (Cartesian sensor, calls run())
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+class TestNAOptimisingPerformance:
+    """Ref uses Cartesian circular sensor (100 points).  Cartesian p data
+    involves Delaunay interpolation that differs between MATLAB and Python,
+    so we only compare p_final (full-grid, no interpolation)."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        from examples.na_optimising_performance import run
+
+        ref = _load_ref("na_optimising_performance")
+        return run(), ref
+
+    def test_p_final(self, scenario):
+        result, ref = scenario
+        _assert_close(
+            np.asarray(result["p_final"]),
+            ref["p_final"][_pml_crop(2)],
+            "p_final",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Custom-run: na_source_smoothing (3 windows, 1D)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+class TestNASourceSmoothing:
+    """Three 1D simulations (no window, Hanning, Blackman).
+    MATLAB ref uses full-grid binary sensor, so we re-run each case with
+    a binary sensor (the example's run() uses a single-point sensor)."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        from examples.na_source_smoothing import _apply_window, setup
+
+        ref = _load_ref("na_source_smoothing")
+        Nx = 256
+
+        results = {}
+        for label, window_type in [
+            ("no_window", None),
+            ("hanning", "Hanning"),
+            ("blackman", "Blackman"),
+        ]:
+            kgrid, medium, source = setup()
+            if window_type is not None:
+                source.p0 = _apply_window(source.p0, Nx, window_type)
+            sensor = kSensor(mask=np.ones(Nx, dtype=bool))
+            sensor.record = ["p", "p_final"]
+            results[label] = kspaceFirstOrder(
+                kgrid,
+                medium,
+                source,
+                sensor,
+                backend="python",
+                quiet=True,
+                pml_inside=True,
+                smooth_p0=False,
+            )
+
+        return results, ref
+
+    @pytest.mark.parametrize("label", ["no_window", "hanning", "blackman"])
+    def test_p(self, scenario, label):
+        results, ref = scenario
+        py_p = np.asarray(results[label]["p"])
+        mat_p = ref[f"p_{label}"]
+        _assert_close(py_p, mat_p, f"p_{label}", thresh=THRESH_TVSP)
+
+    @pytest.mark.parametrize("label", ["no_window", "hanning", "blackman"])
+    def test_p_final(self, scenario, label):
+        results, ref = scenario
+        py_pf = np.asarray(results[label]["p_final"])
+        mat_pf = ref[f"p_final_{label}"]
+        mat_pf = mat_pf[_pml_crop(1)]
+        _assert_close(py_pf, mat_pf, f"p_final_{label}", thresh=THRESH_TVSP)
+
+
+# ---------------------------------------------------------------------------
+# Custom-run: pr_2D_FFT_line_sensor (pml_inside=False, full-grid sensor)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+class TestPR2DFFTLineSensor:
+    """Forward sim with pml_inside=False on 88x216 grid.
+    MATLAB ref uses full-grid binary sensor with PMLInside=false, so we
+    replicate that: setup() gives the 88x216 grid, we add a full-grid
+    binary sensor and run with pml_inside=False."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        from examples.pr_2D_FFT_line_sensor import setup
+
+        kgrid, medium, source = setup()
+        Nx, Ny = 88, 216
+        sensor = kSensor(mask=np.ones((Nx, Ny), dtype=bool))
+        sensor.record = ["p", "p_final"]
+        result = kspaceFirstOrder(
+            kgrid,
+            medium,
+            source,
+            sensor,
+            backend="python",
+            quiet=True,
+            pml_inside=False,
+            pml_size=20,
+            smooth_p0=False,
+        )
+
+        ref = _load_ref("pr_2D_FFT_line_sensor")
+        grid_shape = (int(ref["Nx"]), int(ref["Ny"]))
+        return result, ref, grid_shape
+
+    def test_p(self, scenario):
+        result, ref, grid_shape = scenario
+        matlab_p = _reorder_fullgrid(ref["p"], grid_shape)
+        _assert_close(np.asarray(result["p"]), matlab_p, "p")
+
+    def test_p_final(self, scenario):
+        result, ref, _grid_shape = scenario
+        _assert_close(np.asarray(result["p_final"]), ref["p_final"], "p_final")
+
+
+# ---------------------------------------------------------------------------
+# Custom-run: pr_3D_FFT_planar_sensor (pml_inside=False, blocked by validation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+@pytest.mark.skip(
+    reason="MATLAB ref uses pml_inside=False on 12x44x44 grid; "
+    "Python validation rejects pml_size=10 when Nx=12 (2*pml >= N). "
+    "Needs relaxed pml_inside=False validation."
+)
+class TestPR3DFFTPlanarSensor:
+    """Forward 3D sim. MATLAB ref uses pml_inside=False on 12x44x44 grid
+    (ball centred on 12x44x44). Python validation currently rejects this
+    because 2*pml_size >= Nx. Test will be enabled once the validation
+    is relaxed for pml_inside=False."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        from kwave.data import Vector
+        from kwave.kgrid import kWaveGrid
+        from kwave.kmedium import kWaveMedium
+        from kwave.ksource import kSource
+        from kwave.utils.filters import smooth
+        from kwave.utils.mapgen import make_ball
+
+        pml_size = 10
+        Nx, Ny, Nz = 12, 44, 44
+        dx = dy = dz = 0.2e-3
+        kgrid = kWaveGrid(Vector([Nx, Ny, Nz]), Vector([dx, dy, dz]))
+        medium = kWaveMedium(sound_speed=1500)
+
+        ball_magnitude = 10
+        ball_radius = 3
+        p0 = ball_magnitude * make_ball(
+            Vector([Nx, Ny, Nz]),
+            Vector([Nx // 2, Ny // 2, Nz // 2]),
+            ball_radius,
+        )
+        source = kSource()
+        source.p0 = smooth(p0.astype(float), restore_max=True)
+        kgrid.makeTime(medium.sound_speed)
+
+        sensor = kSensor(mask=np.ones((Nx, Ny, Nz), dtype=bool))
+        sensor.record = ["p", "p_final"]
+        result = kspaceFirstOrder(
+            kgrid,
+            medium,
+            source,
+            sensor,
+            backend="python",
+            quiet=True,
+            pml_inside=False,
+            pml_size=pml_size,
+            smooth_p0=False,
+        )
+        ref = _load_ref("pr_3D_FFT_planar_sensor")
+        grid_shape = (int(ref["Nx"]), int(ref["Ny"]), int(ref["Nz"]))
+        return result, ref, grid_shape
+
+    def test_p(self, scenario):
+        result, ref, grid_shape = scenario
+        matlab_p = _reorder_fullgrid(ref["p"], grid_shape)
+        _assert_close(np.asarray(result["p"]), matlab_p, "p")
+
+    def test_p_final(self, scenario):
+        result, ref, _grid_shape = scenario
+        _assert_close(np.asarray(result["p_final"]), ref["p_final"], "p_final")
+
+
+# ---------------------------------------------------------------------------
+# Custom-run: sd_directional_array_elements (13 elements, calls run())
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+class TestSDDirectionalArrayElements:
+    """13-element semicircular array with per-element averaging."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        from examples.sd_directional_array_elements import run
+
+        ref = _load_ref("sd_directional_array_elements")
+        return run(), ref
+
+    def test_element_data(self, scenario):
+        result, ref = scenario
+        _assert_close(
+            np.asarray(result["element_data"]),
+            ref["element_data"],
+            "element_data",
+            thresh=THRESH_TVSP,
+        )
+
+
+# ---------------------------------------------------------------------------
+# SD directivity modelling 2D/3D -- no MATLAB references yet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.matlab_parity
+class TestSDDirectivityModelling2D:
+    """11 sims with point sources on semicircle, 2D.
+    Skipped until MATLAB reference is generated."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        ref = _load_ref("sd_directivity_modelling_2D")  # will pytest.skip
+        from examples.sd_directivity_modelling_2D import run
+
+        return run(), ref
+
+    def test_single_element_data(self, scenario):
+        result, ref = scenario
+        _assert_close(
+            np.asarray(result["single_element_data"]),
+            ref["single_element_data"],
+            "single_element_data",
+            thresh=THRESH_TVSP,
+        )
+
+
+@pytest.mark.matlab_parity
+class TestSDDirectivityModelling3D:
+    """11 sims on 64^3 grid with point sources on semicircle, 3D.
+    Skipped until MATLAB reference is generated. Slow (~minutes)."""
+
+    @pytest.fixture(scope="class")
+    def scenario(self):
+        ref = _load_ref("sd_directivity_modelling_3D")  # will pytest.skip
+        from examples.sd_directivity_modelling_3D import run
+
+        return run(), ref
+
+    def test_single_element_data(self, scenario):
+        result, ref = scenario
+        _assert_close(
+            np.asarray(result["single_element_data"]),
+            ref["single_element_data"],
+            "single_element_data",
+            thresh=THRESH_TVSP,
+        )

--- a/tests/test_example_parity.py
+++ b/tests/test_example_parity.py
@@ -125,7 +125,7 @@ _EXAMPLES = [
     ("ivp_loading_external_image", 2, THRESH, THRESH),
     ("ivp_photoacoustic_waveforms", 2, THRESH, THRESH),
     # ivp_saving_movie_files: heterogeneous sound_speed + density with makeDisc.
-    # ~1.5% p error due to makeDisc/smooth differences; p_final is tighter.
+    # ~1.5% error due to makeDisc/smooth differences in heterogeneous medium.
     ("ivp_saving_movie_files", 2, 2e-2, 2e-2),
     # TVSP --- p is machine precision, p_final is looser (more FFT round-trips)
     ("tvsp_homogeneous_medium_monopole", 2, THRESH, THRESH_TVSP),
@@ -319,7 +319,6 @@ class TestNASourceSmoothing:
         from examples.na_source_smoothing import _apply_window, setup
 
         ref = _load_ref("na_source_smoothing")
-        Nx = 256
 
         results = {}
         for label, window_type in [
@@ -328,6 +327,7 @@ class TestNASourceSmoothing:
             ("blackman", "Blackman"),
         ]:
             kgrid, medium, source = setup()
+            Nx = int(kgrid.N[0]) if hasattr(kgrid.N, "__len__") else int(kgrid.N)
             if window_type is not None:
                 source.p0 = _apply_window(source.p0, Nx, window_type)
             sensor = kSensor(mask=np.ones(Nx, dtype=bool))
@@ -378,8 +378,8 @@ class TestPR2DFFTLineSensor:
         from examples.pr_2D_FFT_line_sensor import setup
 
         kgrid, medium, source = setup()
-        Nx, Ny = 88, 216
-        sensor = kSensor(mask=np.ones((Nx, Ny), dtype=bool))
+        grid_shape = tuple(int(n) for n in kgrid.N)
+        sensor = kSensor(mask=np.ones(grid_shape, dtype=bool))
         sensor.record = ["p", "p_final"]
         result = kspaceFirstOrder(
             kgrid,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds parity test coverage for 8 previously untested ported examples, filling the `TODO` block that was left as a comment. Each new example required a custom test pattern because it either calls `run()` directly (Cartesian sensor, multi-element averaging, multi-sim loops) or uses non-default solver options (`pml_inside=False`).

**What was added:**
- `ivp_saving_movie_files` promoted into the standard table-driven test with a loose `2e-2` threshold (documented ~1.5 % error from `makeDisc/smooth` differences in heterogeneous medium)
- `TestNAOptimisingPerformance` — calls `run()` and compares only `p_final`; Cartesian `p` is intentionally skipped due to Delaunay interpolation differences
- `TestNASourceSmoothing` — re-runs all three window cases with a full-grid binary sensor; correctly derives `Nx` from `kgrid.N`
- `TestPR2DFFTLineSensor` — replicates `pml_inside=False` run; sensor mask correctly sized from `kgrid.N`
- `TestPR3DFFTPlanarSensor` — properly marked `@pytest.mark.skip` with a clear explanation of the validation blocker
- `TestSDDirectionalArrayElements` — calls `run()` directly and compares per-element averaged time-series
- `TestSDDirectivityModelling2D/3D` — stub classes that auto-skip via `_load_ref` until MATLAB references are generated

**Minor issues noted:**
- In `TestPR2DFFTLineSensor.scenario`, `grid_shape` is overwritten after initially being set from `kgrid.N`; separate variable names would be clearer.
- `pml_size=20` is a literal rather than the module-level `PML_SIZE` constant.

<h3>Confidence Score: 5/5</h3>

Test-only PR with no production code changes; all remaining findings are P2 style suggestions that do not affect correctness.

All new tests are correctly implemented, intentionally skipped, or auto-skip via missing MATLAB refs. Previous P1 concerns from prior threads have been addressed. Only two P2 style items remain, neither of which affects test correctness.

tests/test_example_parity.py — TestPR2DFFTLineSensor.scenario (lines 380–398): grid_shape variable reuse and hardcoded pml_size.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/test_example_parity.py | Adds 8 new parity test classes and moves ivp_saving_movie_files into the standard table; minor grid_shape reuse and hardcoded pml_size in TestPR2DFFTLineSensor. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix Greptile P2s: derive grid sizes from..."](https://github.com/waltsims/k-wave-python/commit/077e83f9d37761451cd3ea6dfd3a26b7f848124e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26697942)</sub>

<!-- /greptile_comment -->