### PR TITLE
Add AlphaMode enum for stringly-typed alpha_mode field

### DIFF
--- a/kwave/enums.py
+++ b/kwave/enums.py
@@ -1,5 +1,17 @@
 from enum import Enum
 
+
+class AlphaMode(str, Enum):
+    """Controls which absorption/dispersion terms are included in the equation of state."""
+
+    NO_ABSORPTION = "no_absorption"
+    NO_DISPERSION = "no_dispersion"
+    STOKES = "stokes"
+
+    def __str__(self):
+        return self.value
+
+
 ################################################################
 # literals that link the discrete cosine and sine transform types with
 # their type definitions in the functions dtt1D, dtt2D, and dtt3D

--- a/kwave/kmedium.py
+++ b/kwave/kmedium.py
@@ -8,6 +8,18 @@ import kwave.utils.checks
 from kwave.enums import AlphaMode
 
 
+def _to_alpha_mode(value):
+    """Normalize a value to AlphaMode. Accepts None, AlphaMode, or a valid string."""
+    if value is None or isinstance(value, AlphaMode):
+        return value
+    try:
+        return AlphaMode(value)
+    except (ValueError, TypeError):
+        raise ValueError(
+            f"medium.alpha_mode must be an AlphaMode enum value or one of " f"'no_absorption', 'no_dispersion', 'stokes', got {value!r}"
+        ) from None
+
+
 @dataclass
 class kWaveMedium(object):
     # sound speed distribution within the acoustic medium [m/s] | required to be defined
@@ -44,8 +56,7 @@ class kWaveMedium(object):
 
     def __post_init__(self):
         self.sound_speed = np.atleast_1d(self.sound_speed)
-        if isinstance(self.alpha_mode, str) and not isinstance(self.alpha_mode, AlphaMode):
-            self.alpha_mode = AlphaMode(self.alpha_mode)
+        self.alpha_mode = _to_alpha_mode(self.alpha_mode)
 
     def check_fields(self, kgrid_shape: np.ndarray) -> None:
         """
@@ -57,12 +68,8 @@ class kWaveMedium(object):
         Returns:
             None
         """
-        # check the absorption mode input is valid (already normalized to AlphaMode in __post_init__)
-        if self.alpha_mode is not None and not isinstance(self.alpha_mode, AlphaMode):
-            raise ValueError(
-                f"medium.alpha_mode must be an AlphaMode enum value or one of "
-                f"'no_absorption', 'no_dispersion', 'stokes', got {self.alpha_mode!r}"
-            )
+        # re-normalize alpha_mode in case it was reassigned as a plain string post-construction
+        self.alpha_mode = _to_alpha_mode(self.alpha_mode)
 
         # check the absorption filter input is valid
         if self.alpha_filter is not None and not (self.alpha_filter.shape == kgrid_shape).all():

--- a/kwave/kmedium.py
+++ b/kwave/kmedium.py
@@ -1,10 +1,11 @@
 import logging
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional, Union
 
 import numpy as np
 
 import kwave.utils.checks
+from kwave.enums import AlphaMode
 
 
 @dataclass
@@ -20,8 +21,8 @@ class kWaveMedium(object):
     # power law absorption exponent
     alpha_power: np.array = None
     # optional input to force either the absorption or dispersion terms in the equation of state to be excluded;
-    # valid inputs are 'no_absorption' or 'no_dispersion'
-    alpha_mode: np.array = None
+    # valid inputs are AlphaMode.NO_ABSORPTION, AlphaMode.NO_DISPERSION, or the equivalent strings
+    alpha_mode: Optional[Union[AlphaMode, str]] = None
     # frequency domain filter applied to the absorption and dispersion terms in the equation of state
     alpha_filter: np.array = None
     # two element array used to control the sign of absorption and dispersion terms in the equation of state
@@ -43,6 +44,8 @@ class kWaveMedium(object):
 
     def __post_init__(self):
         self.sound_speed = np.atleast_1d(self.sound_speed)
+        if isinstance(self.alpha_mode, str) and not isinstance(self.alpha_mode, AlphaMode):
+            self.alpha_mode = AlphaMode(self.alpha_mode)
 
     def check_fields(self, kgrid_shape: np.ndarray) -> None:
         """
@@ -54,13 +57,12 @@ class kWaveMedium(object):
         Returns:
             None
         """
-        # check the absorption mode input is valid
-        if self.alpha_mode is not None:
-            assert self.alpha_mode in [
-                "no_absorption",
-                "no_dispersion",
-                "stokes",
-            ], "medium.alpha_mode must be set to 'no_absorption', 'no_dispersion', or 'stokes'."
+        # check the absorption mode input is valid (already normalized to AlphaMode in __post_init__)
+        if self.alpha_mode is not None and not isinstance(self.alpha_mode, AlphaMode):
+            raise ValueError(
+                f"medium.alpha_mode must be an AlphaMode enum value or one of "
+                f"'no_absorption', 'no_dispersion', 'stokes', got {self.alpha_mode!r}"
+            )
 
         # check the absorption filter input is valid
         if self.alpha_filter is not None and not (self.alpha_filter.shape == kgrid_shape).all():

--- a/tests/test_kmedium.py
+++ b/tests/test_kmedium.py
@@ -1,0 +1,46 @@
+"""Tests for kWaveMedium alpha_mode normalization and validation."""
+import numpy as np
+import pytest
+
+from kwave.enums import AlphaMode
+from kwave.kmedium import kWaveMedium
+
+
+class TestAlphaModeNormalization:
+    def test_default_is_none(self):
+        m = kWaveMedium(sound_speed=1500)
+        assert m.alpha_mode is None
+
+    def test_enum_passes_through(self):
+        m = kWaveMedium(sound_speed=1500, alpha_mode=AlphaMode.NO_DISPERSION)
+        assert m.alpha_mode is AlphaMode.NO_DISPERSION
+
+    @pytest.mark.parametrize("value", ["no_absorption", "no_dispersion", "stokes"])
+    def test_valid_string_normalized_at_construction(self, value):
+        m = kWaveMedium(sound_speed=1500, alpha_mode=value)
+        assert isinstance(m.alpha_mode, AlphaMode)
+        assert m.alpha_mode == value
+
+    def test_invalid_string_at_construction_raises_friendly_error(self):
+        with pytest.raises(ValueError, match="must be an AlphaMode"):
+            kWaveMedium(sound_speed=1500, alpha_mode="garbage")
+
+    def test_post_construction_string_assignment_accepted_by_check_fields(self):
+        m = kWaveMedium(sound_speed=1500, alpha_coeff=np.array(0.5), alpha_power=1.5)
+        m.alpha_mode = "no_dispersion"  # plain string per type hint
+        m.check_fields(np.array([64, 64]))
+        # check_fields normalizes for downstream consumers
+        assert isinstance(m.alpha_mode, AlphaMode)
+        assert m.alpha_mode == "no_dispersion"
+
+    def test_post_construction_invalid_string_rejected_by_check_fields(self):
+        m = kWaveMedium(sound_speed=1500, alpha_coeff=np.array(0.5), alpha_power=1.5)
+        m.alpha_mode = "garbage"
+        with pytest.raises(ValueError, match="must be an AlphaMode"):
+            m.check_fields(np.array([64, 64]))
+
+    def test_string_comparison_still_works(self):
+        # AlphaMode inherits from str, so == against raw strings must keep working
+        m = kWaveMedium(sound_speed=1500, alpha_mode="no_dispersion")
+        assert m.alpha_mode == "no_dispersion"
+        assert m.alpha_mode in ["no_absorption", "no_dispersion"]


### PR DESCRIPTION
- AlphaMode(str, Enum) with NO_ABSORPTION, NO_DISPERSION, STOKES
- kWaveMedium.__post_init__ normalizes string inputs to enum
- Backward compatible: AlphaMode == "no_dispersion" works via str inheritance
- __str__ returns the value so f-strings render cleanly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `AlphaMode(str, Enum)` to replace the stringly-typed `alpha_mode` field and introduces a `_to_alpha_mode` helper that normalises the value at construction time (`__post_init__`) and again inside `check_fields` to cover post-construction string reassignment. Because `AlphaMode` inherits from `str`, all existing equality/membership comparisons across the codebase (`checks.py`, `create_absorption_variables.py`, `kWaveSimulation.py`) continue to work without modification.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only P2 style findings, no logic or correctness issues.

All three changed files are correct. The str-Enum design preserves backward compatibility with every existing string comparison in the codebase. The two previous review concerns (post-construction bypass, unhelpful error message) are both addressed. Only minor style findings remain.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| kwave/enums.py | Adds AlphaMode(str, Enum) with three members and an explicit __str__ that returns self.value for clean f-string rendering. |
| kwave/kmedium.py | Introduces _to_alpha_mode helper, normalizes alpha_mode in __post_init__ and check_fields, handles post-construction string reassignment; field comment omits AlphaMode.STOKES. |
| tests/test_kmedium.py | New test file covering construction normalization, invalid-input errors, post-construction string assignment, and backward-compatible string comparisons. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["caller sets alpha_mode\n(str, AlphaMode, or None)"] --> B{__post_init__ or\ncheck_fields}
    B --> C["_to_alpha_mode(value)"]
    C --> D{value is None or\nalready AlphaMode?}
    D -- Yes --> E["return as-is"]
    D -- No --> F["AlphaMode(value)"]
    F -- valid string --> G["AlphaMode enum member\n(NO_ABSORPTION / NO_DISPERSION / STOKES)"]
    F -- invalid --> H["ValueError with\nfriendly message"]
    G --> I["self.alpha_mode = AlphaMode member"]
    E --> I
    I --> J["Downstream comparisons\nalpha_mode == 'no_dispersion' ✓\nalpha_mode == 'stokes' ✓\nalpha_mode in list ✓"]
```

<sub>Reviews (3): Last reviewed commit: ["Accept post-construction string assignme..."](https://github.com/waltsims/k-wave-python/commit/0a8ae37cccc005c1d8b0e639b3ee453800821b2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27063623)</sub>

<!-- /greptile_comment -->