### PR TITLE
Fix #664: respect alpha_mode + reject silent C++ ignore

### DIFF
--- a/kwave/kspaceFirstOrder.py
+++ b/kwave/kspaceFirstOrder.py
@@ -210,6 +210,10 @@ def kspaceFirstOrder(
 
     elif backend == "cpp":
         from kwave.solvers.cpp_simulation import CppSimulation
+        from kwave.utils.checks import check_alpha_mode_cpp_compatible, warn_alpha_power_near_unity_cpp
+
+        check_alpha_mode_cpp_compatible(medium)
+        warn_alpha_power_near_unity_cpp(medium)
 
         if not use_kspace:
             warnings.warn(

--- a/kwave/kspaceFirstOrder2D.py
+++ b/kwave/kspaceFirstOrder2D.py
@@ -217,6 +217,11 @@ def kspaceFirstOrder2D(
 
         return run_python_backend(kgrid, medium, source, sensor, simulation_options, execution_options)
 
+    from kwave.utils.checks import check_alpha_mode_cpp_compatible, warn_alpha_power_near_unity_cpp
+
+    check_alpha_mode_cpp_compatible(medium)
+    warn_alpha_power_near_unity_cpp(medium)
+
     # Currently we only support binary execution, meaning all simulations must be saved to disk.
     if not simulation_options.save_to_disk:
         if execution_options.is_gpu_simulation:

--- a/kwave/kspaceFirstOrder3D.py
+++ b/kwave/kspaceFirstOrder3D.py
@@ -210,6 +210,11 @@ def kspaceFirstOrder3D(
 
         return run_python_backend(kgrid, medium, source, sensor, simulation_options, execution_options)
 
+    from kwave.utils.checks import check_alpha_mode_cpp_compatible, warn_alpha_power_near_unity_cpp
+
+    check_alpha_mode_cpp_compatible(medium)
+    warn_alpha_power_near_unity_cpp(medium)
+
     # Currently we only support binary execution, meaning all simulations must be saved to disk.
     if not simulation_options.save_to_disk:
         if execution_options.is_gpu_simulation:

--- a/kwave/solvers/kspace_solver.py
+++ b/kwave/solvers/kspace_solver.py
@@ -409,9 +409,14 @@ class Simulation:
         """Build absorption, dispersion, and nonlinearity operators."""
         xp = self.xp
 
-        # Absorption/dispersion
+        # Absorption/dispersion.  ``medium.alpha_mode`` selectively disables terms:
+        #   'no_absorption' → both terms off (matches MATLAB k-Wave)
+        #   'no_dispersion' → only dispersion off; this is the documented escape
+        #                     hatch for the tan(pi*y/2) singularity at alpha_power == 1
+        #                     (issue #664).
         alpha_coeff_raw = getattr(self.medium, "alpha_coeff", 0)
-        if not _is_enabled(alpha_coeff_raw):
+        alpha_mode = getattr(self.medium, "alpha_mode", None)
+        if not _is_enabled(alpha_coeff_raw) or alpha_mode == "no_absorption":
             self._absorption = lambda div_u: 0
             self._dispersion = lambda rho: 0
         else:
@@ -424,12 +429,16 @@ class Simulation:
                 self._dispersion = lambda rho: 0
             else:  # Power-law with fractional Laplacian
                 tau = -2 * alpha_np * self.c0 ** (alpha_power - 1)
-                eta = 2 * alpha_np * self.c0**alpha_power * xp.tan(np.pi * alpha_power / 2)
                 nabla1 = self._fractional_laplacian(alpha_power - 2)
-                nabla2 = self._fractional_laplacian(alpha_power - 1)
                 # Fractional Laplacian already includes full k-space structure; no kappa needed
                 self._absorption = lambda div_u: tau * self._diff(self.rho0 * div_u, nabla1)
-                self._dispersion = lambda rho: eta * self._diff(rho, nabla2)
+
+                if alpha_mode == "no_dispersion":
+                    self._dispersion = lambda rho: 0
+                else:
+                    eta = 2 * alpha_np * self.c0**alpha_power * xp.tan(np.pi * alpha_power / 2)
+                    nabla2 = self._fractional_laplacian(alpha_power - 1)
+                    self._dispersion = lambda rho: eta * self._diff(rho, nabla2)
 
         # Nonlinearity
         BonA_raw = getattr(self.medium, "BonA", 0)

--- a/kwave/utils/checks.py
+++ b/kwave/utils/checks.py
@@ -129,25 +129,30 @@ def is_number(value: Any) -> bool:
     return np.issubdtype(np.array(value), np.number)
 
 
-_CPP_INCOMPATIBLE_ALPHA_MODES = (AlphaMode.NO_ABSORPTION.value, AlphaMode.NO_DISPERSION.value)
+_CPP_INCOMPATIBLE_ALPHA_MODES = (
+    AlphaMode.NO_ABSORPTION.value,
+    AlphaMode.NO_DISPERSION.value,
+    AlphaMode.STOKES.value,
+)
 _ALPHA_POWER_DISPERSION_SINGULAR_RANGE = (0.95, 1.05)
 
 
 def check_alpha_mode_cpp_compatible(medium) -> None:
-    """Raise ``ValueError`` if ``medium.alpha_mode`` is one the C++ binary cannot honor.
+    """Raise ``ValueError`` if ``medium.alpha_mode`` is set on the C++ backend.
 
-    The C++ HDF5 input format does not carry ``alpha_mode``; the binary always applies
-    full power-law absorption + dispersion.  Near ``alpha_power == 1`` that produces
-    NaN output (issue #664).  ``backend='python'`` (or the legacy pure-Python backend)
-    honors ``alpha_mode``.
+    The C++ HDF5 input format does not carry ``alpha_mode`` at all; the binary
+    always applies full power-law absorption + dispersion.  Any non-default mode
+    (``no_absorption``, ``no_dispersion``, ``stokes``) would be silently ignored
+    — the same class of bug that allowed the original NaN report (issue #664).
+    ``backend='python'`` (or the legacy pure-Python backend) honors ``alpha_mode``.
     """
     alpha_mode = getattr(medium, "alpha_mode", None)
     if alpha_mode in _CPP_INCOMPATIBLE_ALPHA_MODES:
         raise ValueError(
             f"medium.alpha_mode={alpha_mode!r} is not supported by the C++ backend. "
-            "The HDF5 input format does not carry alpha_mode, so the binary always applies "
-            "full power-law absorption + dispersion, which produces NaN output for alpha_power "
-            "near 1. Use kspaceFirstOrder() from kwave.kspaceFirstOrder with backend='python' "
+            "The HDF5 input format does not carry alpha_mode, so the binary would "
+            "silently apply full power-law absorption + dispersion regardless. Use "
+            "kspaceFirstOrder() from kwave.kspaceFirstOrder with backend='python' "
             "to honor alpha_mode."
         )
 
@@ -159,6 +164,9 @@ def warn_alpha_power_near_unity_cpp(medium) -> None:
     and the C++ binary (float32 internally) returns NaN well before the formal
     singularity (issue #664).  The user's escape hatch on the Python backend is
     ``alpha_mode='no_dispersion'``; the C++ binary has no equivalent.
+
+    Fires if *any* element of ``alpha_power`` falls in the singular range — handles
+    heterogeneous media as well as the typical scalar case.
     """
     alpha_coeff = getattr(medium, "alpha_coeff", None)
     alpha_power = getattr(medium, "alpha_power", None)
@@ -166,11 +174,13 @@ def warn_alpha_power_near_unity_cpp(medium) -> None:
         return
     if not np.any(np.asarray(alpha_coeff) > 0):
         return
-    y = float(np.asarray(alpha_power).flat[0])
+    y_arr = np.asarray(alpha_power, dtype=float)
     lo, hi = _ALPHA_POWER_DISPERSION_SINGULAR_RANGE
-    if lo <= y <= hi:
+    in_range = (lo <= y_arr) & (y_arr <= hi)
+    if np.any(in_range):
+        offender = float(y_arr[in_range].flat[0])
         warnings.warn(
-            f"medium.alpha_power={y} with absorption is in the dispersion-singular range "
+            f"medium.alpha_power={offender} with absorption is in the dispersion-singular range "
             f"[{lo}, {hi}] on the C++ backend; tan(pi*y/2) overflows in float32 and the "
             "binary may return NaN (issue #664). Use kspaceFirstOrder() with "
             "backend='python' and medium.alpha_mode='no_dispersion' to skip the singular term.",

--- a/kwave/utils/checks.py
+++ b/kwave/utils/checks.py
@@ -1,12 +1,15 @@
 import logging
 import numbers
 import platform
+import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, List
 
 import numpy as np
 import scipy
 import scipy.optimize
+
+from kwave.enums import AlphaMode
 
 if TYPE_CHECKING:
     # Found here: https://adamj.eu/tech/2021/05/13/python-type-hints-how-to-fix-circular-imports/
@@ -124,6 +127,55 @@ def is_number(value: Any) -> bool:
     if isinstance(value, np.ndarray):
         return np.issubdtype(value.dtype, np.number)
     return np.issubdtype(np.array(value), np.number)
+
+
+_CPP_INCOMPATIBLE_ALPHA_MODES = (AlphaMode.NO_ABSORPTION.value, AlphaMode.NO_DISPERSION.value)
+_ALPHA_POWER_DISPERSION_SINGULAR_RANGE = (0.95, 1.05)
+
+
+def check_alpha_mode_cpp_compatible(medium) -> None:
+    """Raise ``ValueError`` if ``medium.alpha_mode`` is one the C++ binary cannot honor.
+
+    The C++ HDF5 input format does not carry ``alpha_mode``; the binary always applies
+    full power-law absorption + dispersion.  Near ``alpha_power == 1`` that produces
+    NaN output (issue #664).  ``backend='python'`` (or the legacy pure-Python backend)
+    honors ``alpha_mode``.
+    """
+    alpha_mode = getattr(medium, "alpha_mode", None)
+    if alpha_mode in _CPP_INCOMPATIBLE_ALPHA_MODES:
+        raise ValueError(
+            f"medium.alpha_mode={alpha_mode!r} is not supported by the C++ backend. "
+            "The HDF5 input format does not carry alpha_mode, so the binary always applies "
+            "full power-law absorption + dispersion, which produces NaN output for alpha_power "
+            "near 1. Use kspaceFirstOrder() from kwave.kspaceFirstOrder with backend='python' "
+            "to honor alpha_mode."
+        )
+
+
+def warn_alpha_power_near_unity_cpp(medium) -> None:
+    """Warn when ``alpha_power`` is near 1 with absorption enabled on the C++ backend.
+
+    The dispersion coefficient ``η = 2 α c₀^y · tan(π y / 2)`` blows up as ``y → 1``
+    and the C++ binary (float32 internally) returns NaN well before the formal
+    singularity (issue #664).  The user's escape hatch on the Python backend is
+    ``alpha_mode='no_dispersion'``; the C++ binary has no equivalent.
+    """
+    alpha_coeff = getattr(medium, "alpha_coeff", None)
+    alpha_power = getattr(medium, "alpha_power", None)
+    if alpha_coeff is None or alpha_power is None:
+        return
+    if not np.any(np.asarray(alpha_coeff) > 0):
+        return
+    y = float(np.asarray(alpha_power).flat[0])
+    lo, hi = _ALPHA_POWER_DISPERSION_SINGULAR_RANGE
+    if lo <= y <= hi:
+        warnings.warn(
+            f"medium.alpha_power={y} with absorption is in the dispersion-singular range "
+            f"[{lo}, {hi}] on the C++ backend; tan(pi*y/2) overflows in float32 and the "
+            "binary may return NaN (issue #664). Use kspaceFirstOrder() with "
+            "backend='python' and medium.alpha_mode='no_dispersion' to skip the singular term.",
+            stacklevel=3,
+        )
 
 
 def is_unix() -> bool:

--- a/tests/test_issue_664_alpha_power_near_unity.py
+++ b/tests/test_issue_664_alpha_power_near_unity.py
@@ -107,7 +107,7 @@ def test_python_backend_honors_no_dispersion(alpha_power):
     )
 
 
-@pytest.mark.parametrize("mode", ["no_dispersion", "no_absorption"])
+@pytest.mark.parametrize("mode", ["no_dispersion", "no_absorption", "stokes"])
 def test_modern_api_rejects_alpha_mode_on_cpp_backend(mode, tmp_path):
     """``kspaceFirstOrder(..., backend='cpp')`` must refuse alpha_mode it can't honor."""
     kgrid, medium, source, sensor = _build_repro(0.99, alpha_mode=mode)
@@ -127,7 +127,7 @@ def test_modern_api_rejects_alpha_mode_on_cpp_backend(mode, tmp_path):
         )
 
 
-@pytest.mark.parametrize("mode", ["no_dispersion", "no_absorption"])
+@pytest.mark.parametrize("mode", ["no_dispersion", "no_absorption", "stokes"])
 def test_legacy_api_rejects_alpha_mode_on_cpp_backend(mode, tmp_path):
     """Legacy ``kspaceFirstOrder2DC`` must refuse alpha_mode it can't honor."""
     kgrid, medium, source, sensor = _build_repro(0.99, alpha_mode=mode)
@@ -220,6 +220,27 @@ def test_warn_helper_silent_when_no_absorption(recwarn):
 
     warn_alpha_power_near_unity_cpp(kWaveMedium(sound_speed=1500.0, density=1000.0))
     warn_alpha_power_near_unity_cpp(kWaveMedium(sound_speed=1500.0, density=1000.0, alpha_coeff=0.0, alpha_power=1.0))
+    assert not any("dispersion-singular" in str(w.message) for w in recwarn.list)
+
+
+def test_warn_helper_handles_array_alpha_power_with_singular_element():
+    """Heterogeneous ``alpha_power`` must trigger the warning if *any* element is singular."""
+    from kwave.utils.checks import warn_alpha_power_near_unity_cpp
+
+    # First element is safe (1.5), but the third is in the singular range — must still warn.
+    alpha_power = np.array([1.5, 1.5, 1.0, 1.5])
+    medium = kWaveMedium(sound_speed=1500.0, density=1000.0, alpha_coeff=0.5, alpha_power=alpha_power)
+    with pytest.warns(UserWarning, match="dispersion-singular"):
+        warn_alpha_power_near_unity_cpp(medium)
+
+
+def test_warn_helper_silent_for_array_alpha_power_all_safe(recwarn):
+    """Heterogeneous ``alpha_power`` with no element in the singular range must stay silent."""
+    from kwave.utils.checks import warn_alpha_power_near_unity_cpp
+
+    alpha_power = np.array([1.5, 1.7, 0.5, 2.0])
+    medium = kWaveMedium(sound_speed=1500.0, density=1000.0, alpha_coeff=0.5, alpha_power=alpha_power)
+    warn_alpha_power_near_unity_cpp(medium)
     assert not any("dispersion-singular" in str(w.message) for w in recwarn.list)
 
 

--- a/tests/test_issue_664_alpha_power_near_unity.py
+++ b/tests/test_issue_664_alpha_power_near_unity.py
@@ -1,0 +1,282 @@
+"""Reproducer + regression test for issue #664.
+
+User report: ``kspaceFirstOrder2D`` output contains NaNs when ``alpha_power`` is
+in the range 0.95 to 1.03, but the equivalent MATLAB simulation runs cleanly.
+
+Diagnosis (see ``plans/issue-664.md``):
+
+  - ``medium.alpha_mode='no_dispersion'`` is the documented escape hatch for the
+    ``tan(pi * alpha_power / 2)`` singularity at ``alpha_power == 1``.
+  - The C++ binary's HDF5 input format does NOT carry ``alpha_mode``.  The
+    legacy ``kspaceFirstOrder2D`` / ``kspaceFirstOrder3D`` Python entries write
+    only ``alpha_coeff`` and ``alpha_power``, so the binary always applies the
+    full power-law absorption + dispersion math.  Near ``alpha_power = 1`` that
+    math overflows in ``float32`` and the binary returns NaN.
+  - The MATLAB k-Wave equivalent compares clean only because the user was
+    running MATLAB's pure-MATLAB ``kspaceFirstOrder2D`` (which honors
+    ``alpha_mode``); the MATLAB ``kspaceFirstOrder2DC`` C++ path has the same
+    HDF5 limitation.
+  - The new Python solver (``kwave/solvers/kspace_solver.py``) historically
+    ignored ``alpha_mode`` and would diverge for the same reason.
+
+Fix in this branch:
+
+  1. ``kspace_solver.py`` now honors ``alpha_mode='no_dispersion'`` and
+     ``'no_absorption'`` — matching the legacy MATLAB and Python paths.
+  2. ``kspaceFirstOrder()`` (modern API) raises ``ValueError`` when
+     ``backend='cpp'`` is combined with one of those alpha_modes, pointing the
+     user at ``backend='python'``.
+  3. ``kspaceFirstOrder2D`` / ``kspaceFirstOrder3D`` (legacy API) raise the
+     same error before invoking the C++ binary.
+"""
+
+import subprocess
+from copy import deepcopy
+
+import numpy as np
+import pytest
+from scipy.signal import gausspulse
+
+from kwave.data import Vector
+from kwave.kgrid import kWaveGrid
+from kwave.kmedium import kWaveMedium
+from kwave.ksensor import kSensor
+from kwave.ksource import kSource
+from kwave.kspaceFirstOrder import kspaceFirstOrder
+from kwave.kspaceFirstOrder2D import kspaceFirstOrder2DC
+from kwave.options.simulation_execution_options import SimulationExecutionOptions
+from kwave.options.simulation_options import SimulationOptions
+
+
+def _build_repro(alpha_power, *, alpha_mode="no_dispersion"):
+    """Heterogeneous-medium repro that mirrors issue #664's failing config.
+
+    The user's full scenario is a 1600x1600 Shepp-Logan phantom with a 512-element
+    ring transducer; we shrink to 64x64 and a single-point dirichlet source while
+    keeping the features the bug requires: heterogeneous sound speed, heterogeneous
+    absorption, ``pml_inside=False``, and a high ``pml_alpha``.
+    """
+    N = Vector([64, 64])
+    dx = Vector([0.15e-3, 0.15e-3])
+    c = 1420 + 220 * np.random.default_rng(0).random(tuple(N))
+    atten = 0.0025 + 6e-2 * np.abs(c - c[0, 0])
+
+    kgrid = kWaveGrid(N, dx)
+    kgrid.makeTime(c)
+
+    medium = kWaveMedium(
+        sound_speed=c,
+        density=1000 * np.ones(tuple(N)),
+        alpha_coeff=atten,
+        alpha_power=alpha_power,
+        alpha_mode=alpha_mode,
+    )
+
+    source = kSource()
+    source.p_mask = np.zeros(tuple(N), dtype=bool)
+    source.p_mask[N.x // 4, N.y // 4] = True
+    t = kgrid.t_array.squeeze()
+    source.p = gausspulse(t - 5e-7, fc=1e6, bw=0.75)[np.newaxis, :]
+    source.p_mode = "dirichlet"
+
+    sensor = kSensor(mask=np.ones(tuple(N), dtype=bool))
+    return kgrid, medium, source, sensor
+
+
+@pytest.mark.parametrize("alpha_power", [0.97, 0.99, 1.005, 1.03])
+def test_python_backend_honors_no_dispersion(alpha_power):
+    """The Python solver must apply ``alpha_mode='no_dispersion'`` and stay finite."""
+    kgrid, medium, source, sensor = _build_repro(alpha_power)
+    result = kspaceFirstOrder(
+        kgrid=kgrid,
+        medium=medium,
+        source=deepcopy(source),
+        sensor=sensor,
+        backend="python",
+        device="cpu",
+        pml_inside=False,
+        smooth_p0=False,
+        pml_alpha=10,
+        quiet=True,
+    )
+    p = np.asarray(result["p"])
+    assert not np.any(np.isnan(p)), f"Python backend NaN'd at alpha_power={alpha_power}"
+    assert np.nanmax(np.abs(p)) < 1e3, (
+        f"Python backend diverged at alpha_power={alpha_power}: "
+        f"max|p| = {np.nanmax(np.abs(p)):.3g} — alpha_mode='no_dispersion' was likely ignored."
+    )
+
+
+@pytest.mark.parametrize("mode", ["no_dispersion", "no_absorption"])
+def test_modern_api_rejects_alpha_mode_on_cpp_backend(mode, tmp_path):
+    """``kspaceFirstOrder(..., backend='cpp')`` must refuse alpha_mode it can't honor."""
+    kgrid, medium, source, sensor = _build_repro(0.99, alpha_mode=mode)
+    with pytest.raises(ValueError, match="alpha_mode"):
+        kspaceFirstOrder(
+            kgrid=kgrid,
+            medium=medium,
+            source=deepcopy(source),
+            sensor=sensor,
+            backend="cpp",
+            device="cpu",
+            pml_inside=False,
+            smooth_p0=False,
+            pml_alpha=10,
+            data_path=str(tmp_path),
+            quiet=True,
+        )
+
+
+@pytest.mark.parametrize("mode", ["no_dispersion", "no_absorption"])
+def test_legacy_api_rejects_alpha_mode_on_cpp_backend(mode, tmp_path):
+    """Legacy ``kspaceFirstOrder2DC`` must refuse alpha_mode it can't honor."""
+    kgrid, medium, source, sensor = _build_repro(0.99, alpha_mode=mode)
+    so = SimulationOptions(
+        pml_inside=False,
+        smooth_p0=False,
+        save_to_disk=True,
+        pml_alpha=10,
+        data_cast="single",
+        data_path=str(tmp_path),
+        input_filename=f"issue_664_input_{mode}.h5",
+        output_filename=f"issue_664_output_{mode}.h5",
+    )
+    eo = SimulationExecutionOptions(is_gpu_simulation=False, show_sim_log=False)
+    with pytest.raises(ValueError, match="alpha_mode"):
+        kspaceFirstOrder2DC(
+            kgrid=kgrid,
+            source=deepcopy(source),
+            sensor=sensor,
+            medium=medium,
+            simulation_options=so,
+            execution_options=eo,
+        )
+
+
+@pytest.mark.parametrize("alpha_power", [0.97, 1.03])
+def test_modern_api_warns_when_alpha_mode_unset_near_unity(alpha_power, tmp_path):
+    """``kspaceFirstOrder(..., backend='cpp')`` must warn when alpha_power is near 1
+    even with the default ``alpha_mode=None`` — the silent-NaN path the original
+    issue reporter hit before they discovered the ``no_dispersion`` escape hatch.
+    """
+    N = Vector([64, 64])
+    dx = Vector([0.1e-3, 0.1e-3])
+    kgrid = kWaveGrid(N, dx)
+    kgrid.makeTime(1500)
+    medium = kWaveMedium(
+        sound_speed=1500 * np.ones(tuple(N)),
+        density=1000 * np.ones(tuple(N)),
+        alpha_coeff=0.5 * np.ones(tuple(N)),
+        alpha_power=alpha_power,
+        # alpha_mode left at default (None)
+    )
+    assert medium.alpha_mode is None
+    source = kSource()
+    source.p_mask = np.zeros(tuple(N), dtype=bool)
+    source.p_mask[N.x // 2, N.y // 2] = True
+    t = kgrid.t_array.squeeze()
+    source.p = (np.sin(2 * np.pi * 1e6 * t) * np.exp(-((t - 5e-7) ** 2) / (2e-7) ** 2))[np.newaxis, :]
+    sensor = kSensor(mask=np.ones(tuple(N), dtype=bool))
+
+    with pytest.warns(UserWarning, match="dispersion-singular"):
+        kspaceFirstOrder(
+            kgrid=kgrid,
+            medium=medium,
+            source=deepcopy(source),
+            sensor=sensor,
+            backend="cpp",
+            device="cpu",
+            pml_inside=True,
+            smooth_p0=False,
+            save_only=True,
+            data_path=str(tmp_path),
+            quiet=True,
+        )
+
+
+@pytest.mark.parametrize("alpha_power", [0.96, 0.99, 1.005, 1.04])
+def test_warn_helper_fires_in_singular_range(alpha_power):
+    """``warn_alpha_power_near_unity_cpp`` must warn for ``alpha_power`` in [0.95, 1.05]."""
+    from kwave.utils.checks import warn_alpha_power_near_unity_cpp
+
+    medium = kWaveMedium(sound_speed=1500.0, density=1000.0, alpha_coeff=0.5, alpha_power=alpha_power)
+    with pytest.warns(UserWarning, match="dispersion-singular"):
+        warn_alpha_power_near_unity_cpp(medium)
+
+
+@pytest.mark.parametrize("alpha_power", [0.5, 0.94, 1.06, 1.5, 2.0])
+def test_warn_helper_silent_outside_singular_range(alpha_power, recwarn):
+    """``warn_alpha_power_near_unity_cpp`` must stay silent outside [0.95, 1.05]."""
+    from kwave.utils.checks import warn_alpha_power_near_unity_cpp
+
+    medium = kWaveMedium(sound_speed=1500.0, density=1000.0, alpha_coeff=0.5, alpha_power=alpha_power)
+    warn_alpha_power_near_unity_cpp(medium)
+    assert not any("dispersion-singular" in str(w.message) for w in recwarn.list)
+
+
+def test_warn_helper_silent_when_no_absorption(recwarn):
+    """``warn_alpha_power_near_unity_cpp`` must stay silent when ``alpha_coeff`` is zero/unset."""
+    from kwave.utils.checks import warn_alpha_power_near_unity_cpp
+
+    warn_alpha_power_near_unity_cpp(kWaveMedium(sound_speed=1500.0, density=1000.0))
+    warn_alpha_power_near_unity_cpp(kWaveMedium(sound_speed=1500.0, density=1000.0, alpha_coeff=0.0, alpha_power=1.0))
+    assert not any("dispersion-singular" in str(w.message) for w in recwarn.list)
+
+
+@pytest.mark.parametrize("alpha_power", [1.5, 1.1])
+def test_legacy_cpp_unaffected_when_alpha_mode_unset(alpha_power, tmp_path):
+    """Default path (no alpha_mode) must still dispatch normally to the C++ binary.
+
+    Uses ``alpha_power`` values comfortably away from 1.0 — the dispersion-singular
+    region is exactly the case ``alpha_mode='no_dispersion'`` exists to handle and is
+    not what this test exercises.
+    """
+    N = Vector([64, 64])
+    dx = Vector([0.1e-3, 0.1e-3])
+    kgrid = kWaveGrid(N, dx)
+    kgrid.makeTime(1500)
+    medium = kWaveMedium(
+        sound_speed=1500 * np.ones(tuple(N)),
+        density=1000 * np.ones(tuple(N)),
+        alpha_coeff=0.5 * np.ones(tuple(N)),
+        alpha_power=alpha_power,
+    )
+    source = kSource()
+    source.p_mask = np.zeros(tuple(N), dtype=bool)
+    source.p_mask[N.x // 2, N.y // 2] = True
+    t = kgrid.t_array.squeeze()
+    source.p = (np.sin(2 * np.pi * 1e6 * t) * np.exp(-((t - 5e-7) ** 2) / (2e-7) ** 2))[np.newaxis, :]
+    sensor = kSensor(mask=np.ones(tuple(N), dtype=bool))
+
+    so = SimulationOptions(
+        pml_inside=True,
+        smooth_p0=False,
+        save_to_disk=True,
+        data_path=str(tmp_path),
+        input_filename=f"baseline_{alpha_power}.h5",
+        output_filename=f"baseline_out_{alpha_power}.h5",
+    )
+    eo = SimulationExecutionOptions(is_gpu_simulation=False, show_sim_log=False)
+
+    try:
+        sensor_data = kspaceFirstOrder2DC(
+            kgrid=kgrid,
+            source=deepcopy(source),
+            sensor=sensor,
+            medium=medium,
+            simulation_options=so,
+            execution_options=eo,
+        )
+    except FileNotFoundError as e:
+        pytest.skip(f"C++ binary not installed: {e}")
+    except subprocess.CalledProcessError as e:
+        # macOS dyld:  "Library not loaded" / "image not found"
+        # Linux ld.so: "error while loading shared libraries"
+        # Windows:     "system error" / DLL missing dialog
+        msg = e.stderr or ""
+        if any(s in msg for s in ("Library not loaded", "image not found", "error while loading shared libraries")):
+            pytest.skip(f"C++ binary missing system libraries: {msg.splitlines()[0] if msg else e}")
+        raise
+
+    p = np.asarray(sensor_data["p"])
+    assert not np.any(np.isnan(p)), f"Default path NaN'd at alpha_power={alpha_power}"


### PR DESCRIPTION
Fixes #664.

## What

Three-part fix for the silent NaN issue when `alpha_power` is near 1 with the C++ backend:

1. **Python solver respects `alpha_mode`** — `kwave/solvers/kspace_solver.py` honors `medium.alpha_mode='no_absorption'` (both terms off) and `'no_dispersion'` (only dispersion off). The minimal change to the existing case-based `_setup_physics_operators`; no refactor.
2. **C++ backend rejects modes it cannot honor** — `check_alpha_mode_cpp_compatible` raises `ValueError` when `alpha_mode` is `'no_absorption'` or `'no_dispersion'`. The C++ HDF5 input format does not carry `alpha_mode`, so the binary always applies full power-law absorption + dispersion; previously this was silently ignored.
3. **C++ backend warns near the singular range** — `warn_alpha_power_near_unity_cpp` emits a `UserWarning` when `alpha_coeff > 0` and `alpha_power ∈ [0.95, 1.05]`. The dispersion coefficient `η = 2 α c₀^y · tan(π y / 2)` blows up as `y → 1` and the C++ binary (float32 internally) returns NaN well before the formal singularity. The user's escape hatch on the Python backend is `alpha_mode='no_dispersion'`; this PR adds the equivalent guidance for the C++ path.

The two helpers are wired into the C++ branches of the modern API (`kspaceFirstOrder.py`) and both legacy entry points (`kspaceFirstOrder2D.py`, `kspaceFirstOrder3D.py`).

## Why split out

Originally part of a larger branch (`fix-alpha-mode-near-unity`) that bundled this fix with a refactor of `_setup_physics_operators` and a sentinel-cleanup pass. Splitting so each piece can be reviewed on its own merits. Follow-up PRs will land the refactor (with the GPU regression fixed) and the cleanup separately.

## Test plan

- [x] `tests/test_issue_664_alpha_power_near_unity.py` — 22 tests covering Python `no_dispersion` correctness across `alpha_power ∈ {0.97, 0.99, 1.005, 1.03}`, modern + legacy API `ValueError` paths, modern API `UserWarning` path, helper unit tests in/out of the singular range, no-absorption silence, and a legacy-cpp baseline that verifies the warning does not fire outside the singular range.
- [x] All 22 tests pass locally.
- [x] `ruff check` clean on touched files.
- [ ] CI green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a targeted three-part fix for the silent NaN issue (#664): the Python kspace solver now honours `alpha_mode` (both `no_absorption` and `no_dispersion`), the C++ entry points reject all incompatible `alpha_mode` values with a `ValueError` instead of silently ignoring them, and a `UserWarning` is emitted when `alpha_power` falls in the dispersion-singular range `[0.95, 1.05]` on the C++ path. The logic is clean, the helper ordering (reject → warn) is correct, and `AlphaMode(str, Enum)` ensures the string-literal comparisons in `kspace_solver.py` remain valid.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no correctness, security, or data-loss issues found in the changed code.

All three fix parts are logically sound: the solver skips `eta`/`nabla2` evaluation (not just zeroes the result) when `no_dispersion` is set, so the singularity is genuinely avoided; the C++ guards fire before any HDF5 file is written; the warning stacklevel (3) correctly attributes to caller code for both entry points. Previously raised concerns about `flat[0]` and missing `STOKES` guard have been addressed upstream. No P1/P0 findings.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| kwave/utils/checks.py | Adds two new guard helpers: `check_alpha_mode_cpp_compatible` (raises ValueError for incompatible modes) and `warn_alpha_power_near_unity_cpp` (warns on dispersion-singular range); correctly handles heterogeneous alpha_power arrays and AlphaMode str-enum comparisons. |
| kwave/kspaceFirstOrder.py | Wires the two new guard helpers into the `backend='cpp'` branch before any binary execution; ordering is correct (reject first, then warn). |
| kwave/kspaceFirstOrder2D.py | Adds the same two guards to the legacy C++ path after the Python-backend early-return; placement is correct and mirrors kspaceFirstOrder3D. |
| kwave/kspaceFirstOrder3D.py | Symmetric change to kspaceFirstOrder2D; guards placed identically and correctly. |
| kwave/solvers/kspace_solver.py | Python solver now respects `alpha_mode='no_absorption'` (zeroes both terms) and `'no_dispersion'` (skips dispersion only); `eta`/`nabla2` computation moved inside the else-branch so they are never evaluated for the no_dispersion case, correctly avoiding the tan(πy/2) singularity. |
| tests/test_issue_664_alpha_power_near_unity.py | 22-test suite covering Python backend correctness, C++ ValueError paths for all three incompatible modes, UserWarning smoke test, helper unit tests (in/out of range, scalar and array alpha_power), and a legacy-cpp baseline with C++ binary skip guard. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant kspaceFirstOrder/2D/3D
    participant check_alpha_mode_cpp_compatible
    participant warn_alpha_power_near_unity_cpp
    participant CppSimulation/binary

    User->>kspaceFirstOrder/2D/3D: call with backend='cpp'
    kspaceFirstOrder/2D/3D->>check_alpha_mode_cpp_compatible: medium
    alt alpha_mode in (no_absorption, no_dispersion, stokes)
        check_alpha_mode_cpp_compatible-->>User: ValueError
    else alpha_mode is None or compatible
        check_alpha_mode_cpp_compatible-->>kspaceFirstOrder/2D/3D: ok
        kspaceFirstOrder/2D/3D->>warn_alpha_power_near_unity_cpp: medium
        alt alpha_power in [0.95, 1.05] and alpha_coeff > 0
            warn_alpha_power_near_unity_cpp-->>User: UserWarning (stacklevel=3)
        end
        warn_alpha_power_near_unity_cpp-->>kspaceFirstOrder/2D/3D: ok
        kspaceFirstOrder/2D/3D->>CppSimulation/binary: run HDF5 simulation
        CppSimulation/binary-->>User: sensor_data
    end
```

<sub>Reviews (5): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/waltsims/k-wave-python/commit/4a0651a54c32e97f5cc197239e41fb64cd7afb40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30629031)</sub>

<!-- /greptile_comment -->