### PR TITLE
Make step() branch-free by binding lambdas at setup

### DIFF
--- a/kwave/solvers/kspace_solver.py
+++ b/kwave/solvers/kspace_solver.py
@@ -428,46 +428,59 @@ class Simulation:
         return db2neper(alpha_coeff, alpha_power), alpha_power
 
     def _init_absorption(self, alpha_np, alpha_power):
-        """Set ``self.tau`` and ``self.nabla1`` for the power-law absorption term.
+        """Bind ``self._absorption(div_u)`` to the configured power-law term.
 
-        ``tau is None`` means the term is disabled (``alpha_coeff = 0`` or
-        ``alpha_mode = 'no_absorption'``).  Stokes (``alpha_power == 2``) keeps
-        ``nabla1 = None`` -- ``_diff`` treats that as the identity operator, so the
-        term collapses to ``tau * rho0 * div_u`` without an FFT round-trip.
+        Three branches, decided once at setup so ``step()`` can call the bound
+        lambda branch-free:
+
+        - disabled (``alpha_coeff = 0`` or ``alpha_mode = 'no_absorption'``):
+          returns ``0`` directly, no FFT.
+        - Stokes (``alpha_power == 2``): ``-2 alpha c0 rho0 * div_u``, no FFT
+          (matches the original direct-multiply Stokes path).
+        - full power-law: ``tau * F^-1[nabla1 * F[rho0 * div_u]]``.
         """
         alpha_mode = getattr(self.medium, "alpha_mode", None)
         if alpha_np is None or alpha_mode == "no_absorption":
-            self.tau = None
-            self.nabla1 = None
-            return
-        if abs(alpha_power - 2.0) < 1e-10:  # Stokes
-            self.tau = -2 * alpha_np * self.c0
-            self.nabla1 = None
+            self._absorption = lambda div_u: 0
+        elif abs(alpha_power - 2.0) < 1e-10:  # Stokes
+            tau = -2 * alpha_np * self.c0
+            self._absorption = lambda div_u: tau * self.rho0 * div_u
         else:
-            self.tau = -2 * alpha_np * self.c0 ** (alpha_power - 1)
-            self.nabla1 = self._fractional_laplacian(alpha_power - 2)
+            tau = -2 * alpha_np * self.c0 ** (alpha_power - 1)
+            nabla1 = self._fractional_laplacian(alpha_power - 2)
+            self._absorption = lambda div_u: tau * self._diff(self.rho0 * div_u, nabla1)
 
     def _init_dispersion(self, alpha_np, alpha_power):
-        """Set ``self.eta`` and ``self.nabla2`` for the power-law dispersion term.
+        """Bind ``self._dispersion(rho)`` to the configured power-law term.
 
-        ``eta is None`` means the term is disabled (``alpha_mode = 'no_absorption'``,
-        ``'no_dispersion'``, or Stokes).  ``tan(pi*y/2)`` is the singular factor that
-        blows up as ``alpha_power -> 1``, so ``no_dispersion`` is the safe path near
-        unity (issue #664).
+        Disabled when ``alpha_coeff = 0``, ``alpha_mode in {'no_absorption',
+        'no_dispersion'}``, or Stokes (``alpha_power == 2``).  ``no_dispersion``
+        is the documented escape hatch for the ``tan(pi*y/2)`` singularity at
+        ``alpha_power -> 1`` (issue #664).
         """
         alpha_mode = getattr(self.medium, "alpha_mode", None)
         is_stokes = alpha_power is not None and abs(alpha_power - 2.0) < 1e-10
         if alpha_np is None or alpha_mode in ("no_absorption", "no_dispersion") or is_stokes:
-            self.eta = None
-            self.nabla2 = None
-            return
-        self.eta = 2 * alpha_np * self.c0**alpha_power * self.xp.tan(np.pi * alpha_power / 2)
-        self.nabla2 = self._fractional_laplacian(alpha_power - 1)
+            self._dispersion = lambda rho: 0
+        else:
+            eta = 2 * alpha_np * self.c0**alpha_power * self.xp.tan(np.pi * alpha_power / 2)
+            nabla2 = self._fractional_laplacian(alpha_power - 1)
+            self._dispersion = lambda rho: eta * self._diff(rho, nabla2)
 
     def _init_nonlinearity(self):
-        """Set ``self.BonA`` for the nonlinearity term. ``None`` means disabled."""
+        """Bind ``self._nonlinearity(rho)`` and ``self._nl_factor(rho_split)``.
+
+        Disabled when ``BonA = 0`` (or unset): both lambdas short-circuit so
+        ``step()`` neither sums ``rho_split`` nor evaluates the nonlinear term.
+        """
         BonA_raw = getattr(self.medium, "BonA", 0)
-        self.BonA = _expand_to_grid(BonA_raw, self.grid_shape, self.xp, "BonA") if _is_enabled(BonA_raw) else None
+        if not _is_enabled(BonA_raw):
+            self._nonlinearity = lambda rho: 0
+            self._nl_factor = lambda rho_split: 1.0
+        else:
+            BonA = _expand_to_grid(BonA_raw, self.grid_shape, self.xp, "BonA")
+            self._nonlinearity = lambda rho: BonA * rho**2 / (2 * self.rho0)
+            self._nl_factor = lambda rho_split: (2 * sum(rho_split) + self.rho0) / self.rho0
 
     def _setup_source_operators(self):
         """Build time-varying source injection operators.
@@ -626,8 +639,7 @@ class Simulation:
             self.u[i] = self._source_u_ops[i](self.t, self.u[i])
 
         # Mass conservation: drho_i/dt = -rho0 * div_i(u_i) * nl_factor, with PML
-        has_nonlinearity = self.BonA is not None
-        nl_factor = (2 * sum(self.rho_split) + self.rho0) / self.rho0 if has_nonlinearity else 1.0
+        nl_factor = self._nl_factor(self.rho_split)
         div_u_total = xp.zeros(self.grid_shape, dtype=float)
         for i in range(self.ndim):
             pml = self.pml_list[i]
@@ -638,10 +650,9 @@ class Simulation:
 
         # Equation of state:  p = c0^2 * (rho + absorption - dispersion + nonlinearity)
         rho_total = sum(self.rho_split)
-        absorption = self.tau * self._diff(self.rho0 * div_u_total, self.nabla1) if self.tau is not None else 0
-        dispersion = self.eta * self._diff(rho_total, self.nabla2) if self.eta is not None else 0
-        nonlinearity = self.BonA * rho_total**2 / (2 * self.rho0) if has_nonlinearity else 0
-        self.p = self.c0_sq * (rho_total + absorption - dispersion + nonlinearity)
+        self.p = self.c0_sq * (
+            rho_total + self._absorption(div_u_total) - self._dispersion(rho_total) + self._nonlinearity(rho_total)
+        )
 
         # At t=0, override equation of state with p0; set u(dt/2) for leapfrog.
         # MATLAB convention (kspaceFirstOrder2D.m line 920): u(dt/2) = +dt/(2*rho) * grad(p0)

--- a/kwave/solvers/kspace_solver.py
+++ b/kwave/solvers/kspace_solver.py
@@ -428,58 +428,84 @@ class Simulation:
         return db2neper(alpha_coeff, alpha_power), alpha_power
 
     def _init_absorption(self, alpha_np, alpha_power):
-        """Bind ``self._absorption(div_u)`` to the configured power-law term.
+        """Bind absorption coefficients and the ``step()`` dispatch lambda.
 
-        Three branches, decided once at setup so ``step()`` can call the bound
-        lambda branch-free:
+        Sets, for introspection by numerical users:
 
-        - disabled (``alpha_coeff = 0`` or ``alpha_mode = 'no_absorption'``):
-          returns ``0`` directly, no FFT.
-        - Stokes (``alpha_power == 2``): ``-2 alpha c0 rho0 * div_u``, no FFT
-          (matches the original direct-multiply Stokes path).
-        - full power-law: ``tau * F^-1[nabla1 * F[rho0 * div_u]]``.
+        - ``self.tau`` -- absorption coefficient on the grid, ``None`` if disabled.
+          Stokes uses ``-2 alpha c0``; power-law uses ``-2 alpha c0^(y-1)``.
+        - ``self.nabla1`` -- ``|k|^(y-2)`` fractional-Laplacian operator in
+          k-space, or ``None`` for Stokes / disabled (no FFT round-trip).
+
+        And binds ``self._absorption(div_u)`` for branch-free invocation in
+        ``step()``.  The lambda reads from ``self.tau`` / ``self.nabla1`` so a
+        post-setup tweak (``sim.tau *= 1.1``) is picked up automatically;
+        toggling enabled<->disabled requires re-running setup.
         """
         alpha_mode = getattr(self.medium, "alpha_mode", None)
         if alpha_np is None or alpha_mode == "no_absorption":
+            self.tau = None
+            self.nabla1 = None
             self._absorption = lambda div_u: 0
         elif abs(alpha_power - 2.0) < 1e-10:  # Stokes
-            tau = -2 * alpha_np * self.c0
-            self._absorption = lambda div_u: tau * self.rho0 * div_u
-        else:
-            tau = -2 * alpha_np * self.c0 ** (alpha_power - 1)
-            nabla1 = self._fractional_laplacian(alpha_power - 2)
-            self._absorption = lambda div_u: tau * self._diff(self.rho0 * div_u, nabla1)
+            self.tau = -2 * alpha_np * self.c0
+            self.nabla1 = None  # no fractional Laplacian; direct multiply
+            self._absorption = lambda div_u: self.tau * self.rho0 * div_u
+        else:  # full power-law
+            self.tau = -2 * alpha_np * self.c0 ** (alpha_power - 1)
+            self.nabla1 = self._fractional_laplacian(alpha_power - 2)
+            self._absorption = lambda div_u: self.tau * self._diff(self.rho0 * div_u, self.nabla1)
 
     def _init_dispersion(self, alpha_np, alpha_power):
-        """Bind ``self._dispersion(rho)`` to the configured power-law term.
+        """Bind dispersion coefficients and the ``step()`` dispatch lambda.
+
+        Sets, for introspection:
+
+        - ``self.eta`` -- dispersion coefficient ``2 alpha c0^y * tan(pi y / 2)``
+          on the grid, ``None`` if disabled.  ``tan(pi y / 2)`` is the singular
+          factor that blows up as ``alpha_power -> 1`` (issue #664) -- check
+          ``sim.eta`` to see the magnitude near unity.
+        - ``self.nabla2`` -- ``|k|^(y-1)`` fractional-Laplacian operator, or
+          ``None`` if disabled.
 
         Disabled when ``alpha_coeff = 0``, ``alpha_mode in {'no_absorption',
-        'no_dispersion'}``, or Stokes (``alpha_power == 2``).  ``no_dispersion``
-        is the documented escape hatch for the ``tan(pi*y/2)`` singularity at
-        ``alpha_power -> 1`` (issue #664).
+        'no_dispersion'}``, or Stokes (``alpha_power == 2``).
         """
         alpha_mode = getattr(self.medium, "alpha_mode", None)
         is_stokes = alpha_power is not None and abs(alpha_power - 2.0) < 1e-10
         if alpha_np is None or alpha_mode in ("no_absorption", "no_dispersion") or is_stokes:
+            self.eta = None
+            self.nabla2 = None
             self._dispersion = lambda rho: 0
         else:
-            eta = 2 * alpha_np * self.c0**alpha_power * self.xp.tan(np.pi * alpha_power / 2)
-            nabla2 = self._fractional_laplacian(alpha_power - 1)
-            self._dispersion = lambda rho: eta * self._diff(rho, nabla2)
+            self.eta = 2 * alpha_np * self.c0**alpha_power * self.xp.tan(np.pi * alpha_power / 2)
+            self.nabla2 = self._fractional_laplacian(alpha_power - 1)
+            self._dispersion = lambda rho: self.eta * self._diff(rho, self.nabla2)
 
     def _init_nonlinearity(self):
-        """Bind ``self._nonlinearity(rho)`` and ``self._nl_factor(rho_split)``.
+        """Bind the nonlinearity coefficient and ``step()`` dispatch lambdas.
 
-        Disabled when ``BonA = 0`` (or unset): both lambdas short-circuit so
-        ``step()`` neither sums ``rho_split`` nor evaluates the nonlinear term.
+        Sets, for introspection:
+
+        - ``self.BonA`` -- nonlinearity parameter B/A on the grid, ``None`` if
+          disabled.
+
+        And binds two callables for branch-free use in ``step()``:
+
+        - ``self._nonlinearity(rho)`` -- the additive nonlinear term in the
+          equation of state.
+        - ``self._nl_factor(rho_split)`` -- the multiplicative factor on the
+          mass-conservation update.  Lossless path returns ``1.0`` without
+          summing ``rho_split``.
         """
         BonA_raw = getattr(self.medium, "BonA", 0)
         if not _is_enabled(BonA_raw):
+            self.BonA = None
             self._nonlinearity = lambda rho: 0
             self._nl_factor = lambda rho_split: 1.0
         else:
-            BonA = _expand_to_grid(BonA_raw, self.grid_shape, self.xp, "BonA")
-            self._nonlinearity = lambda rho: BonA * rho**2 / (2 * self.rho0)
+            self.BonA = _expand_to_grid(BonA_raw, self.grid_shape, self.xp, "BonA")
+            self._nonlinearity = lambda rho: self.BonA * rho**2 / (2 * self.rho0)
             self._nl_factor = lambda rho_split: (2 * sum(rho_split) + self.rho0) / self.rho0
 
     def _setup_source_operators(self):


### PR DESCRIPTION
## Why

After #713 landed the `_setup_physics_operators` refactor, `step()` had three runtime conditionals per timestep:

\`\`\`python
absorption    = self.tau  * self._diff(...) if self.tau is not None else 0
dispersion    = self.eta  * self._diff(...) if self.eta is not None else 0
nonlinearity  = self.BonA * rho_total**2 / ... if has_nonlinearity else 0
\`\`\`

These checks don't change during a simulation — they're decided once by the medium configuration. Move them to setup, where they belong.

## What

Each `_init_*` now binds a callable instead of setting raw attributes:

- `self._absorption(div_u)` — disabled / Stokes / full power-law
- `self._dispersion(rho)` — disabled / full power-law
- `self._nonlinearity(rho)` — disabled / enabled
- `self._nl_factor(rho_split)` — `1.0` for lossless or `(2 * sum(rho_split) + rho0) / rho0`

`step()` reduces to:

\`\`\`python
nl_factor = self._nl_factor(self.rho_split)
# ...
rho_total = sum(self.rho_split)
self.p = self.c0_sq * (
    rho_total
    + self._absorption(div_u_total)
    - self._dispersion(rho_total)
    + self._nonlinearity(rho_total)
)
\`\`\`

No branches in the hot loop.

## Performance

Disabled paths still short-circuit:
- Lossless `_nl_factor` returns `1.0` without summing `rho_split`
- Disabled absorption/dispersion/nonlinearity lambdas return `0` directly (no FFT, no array math)

Function-call dispatch (~100ns/call × 4 calls = 400ns/step) is in the same noise floor as `is not None` checks were. The expensive work (FFTs, array ops) is unchanged.

## Test plan

- [x] `tests/test_issue_664_alpha_power_near_unity.py` — 26 pass + 1 GPU skip
- [x] `tests/test_native_solver.py` — 35 pass (covers heterogeneous absorption, Stokes, BonA nonlinearity, sensors)
- [x] `tests/test_ivp_homogeneous_medium.py` — 1 pass
- [x] `ruff check` clean
- [ ] CI green

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves three per-timestep conditionals (`tau is not None`, `eta is not None`, `BonA is not None`) out of `step()` and into the `_init_*` setup methods, binding lambdas that either return `0`/`1.0` immediately or perform the full FFT-based computation. All four dispatch paths (`_absorption`, `_dispersion`, `_nonlinearity`, `_nl_factor`) produce results mathematically identical to the old inline expressions, including the Stokes short-circuit (`nabla1=None` → identity in `_diff`) and the DC-safe treatment noted in the `_diff` docstring.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactoring is a clean, behavior-preserving reorganization with no functional changes to the physics.

Every new lambda maps 1-to-1 to the expression it replaced: disabled paths return the same sentinel values (integer `0` / `1.0`), Stokes avoids the FFT round-trip in the same way, full power-law forwards to `_diff` with the same operands, and `_nl_factor` is called at the same point in `step()` (before the mass-conservation loop) with the same `rho_split` list. No silent behavioral change was found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| kwave/solvers/kspace_solver.py | Refactors three runtime conditionals in `step()` into lambdas bound at setup time; all four dispatch paths (absorption, dispersion, nonlinearity, nl_factor) are mathematically equivalent to the original expressions |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant S as Simulation
    participant Setup as _setup_physics_operators
    participant Step as step()

    S->>Setup: _setup_physics_operators()
    Setup->>Setup: _init_absorption() → self._absorption λ
    Note right of Setup: disabled: λ(div_u)→0<br/>Stokes: λ(div_u)→τ·ρ₀·div_u<br/>power-law: λ(div_u)→τ·_diff(ρ₀·div_u,∇₁)
    Setup->>Setup: _init_dispersion() → self._dispersion λ
    Note right of Setup: disabled: λ(ρ)→0<br/>enabled: λ(ρ)→η·_diff(ρ,∇₂)
    Setup->>Setup: _init_nonlinearity() → self._nonlinearity λ + self._nl_factor λ
    Note right of Setup: disabled: λ(ρ)→0, nl_factor→1.0<br/>enabled: λ(ρ)→(B/A·ρ²)/(2ρ₀), nl_factor→(2Σρ+ρ₀)/ρ₀

    loop each timestep
        S->>Step: step()
        Step->>Step: nl_factor = self._nl_factor(rho_split)
        Step->>Step: div_u_total accumulate
        Step->>Step: rho_split update with nl_factor
        Step->>Step: rho_total = sum(rho_split)
        Step->>Step: p = c0² · (ρ + _absorption(div_u) - _dispersion(ρ) + _nonlinearity(ρ))
    end
```

<sub>Reviews (2): Last reviewed commit: ["Restore tau/eta/nabla1/nabla2/BonA as in..."](https://github.com/waltsims/k-wave-python/commit/4e97afed5e6c9b0cebd230303256a987064f0f9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30639065)</sub>

<!-- /greptile_comment -->