### PR TITLE
Use np.pi and remove redundant variable in gaussian function

### DIFF
--- a/kwave/kWaveSimulation_helper/create_absorption_variables.py
+++ b/kwave/kWaveSimulation_helper/create_absorption_variables.py
@@ -12,19 +12,19 @@ def create_absorption_variables(kgrid: kWaveGrid, medium: kWaveMedium, equation_
     # define the lossy derivative operators and proportionality coefficients
     """
     Selects and returns absorption and dispersion operators and coefficients for the given medium based on the equation of state.
-    
+
     Parameters:
         kgrid (kWaveGrid): Grid object providing wavenumber array via `kgrid.k`.
         medium (kWaveMedium): Medium properties used to compute absorption/dispersion coefficients.
         equation_of_state (str): One of `"absorbing"`, `"stokes"`, or `"lossless"` determining which variables to produce.
-    
+
     Returns:
         tuple: (nabla1, nabla2, tau, eta)
             - nabla1: First-order absorption operator or `None` when not applicable.
             - nabla2: Dispersion operator or `None` when not applicable.
             - tau: Absorbing coefficient or `None` when not applicable.
             - eta: Dispersive coefficient or `None` when not applicable.
-    
+
     Behavior:
         - "absorbing": returns (nabla1, nabla2, tau, eta) computed for an absorbing medium.
         - "stokes": returns (None, None, tau, None) where `tau` is the Stokes absorbing coefficient.

--- a/kwave/solvers/kspace_solver.py
+++ b/kwave/solvers/kspace_solver.py
@@ -676,9 +676,7 @@ class Simulation:
 
         # Equation of state:  p = c0^2 * (rho + absorption - dispersion + nonlinearity)
         rho_total = sum(self.rho_split)
-        self.p = self.c0_sq * (
-            rho_total + self._absorption(div_u_total) - self._dispersion(rho_total) + self._nonlinearity(rho_total)
-        )
+        self.p = self.c0_sq * (rho_total + self._absorption(div_u_total) - self._dispersion(rho_total) + self._nonlinearity(rho_total))
 
         # At t=0, override equation of state with p0; set u(dt/2) for leapfrog.
         # MATLAB convention (kspaceFirstOrder2D.m line 920): u(dt/2) = +dt/(2*rho) * grad(p0)

--- a/kwave/utils/math.py
+++ b/kwave/utils/math.py
@@ -374,11 +374,9 @@ def gaussian(
 
     """
     if magnitude is None:
-        magnitude = (2 * math.pi * variance) ** -0.5
+        magnitude = (2 * np.pi * variance) ** -0.5
 
-    gauss_distr = magnitude * np.exp(-((x - mean) ** 2) / (2 * variance))
-
-    return gauss_distr
+    return magnitude * np.exp(-((x - mean) ** 2) / (2 * variance))
 
 
 def _compute_direction(start_pos: np.ndarray, end_pos: np.ndarray) -> Tuple[np.ndarray, float]:


### PR DESCRIPTION
Wow, this is a cool repo! I made a small cleanup to the `gaussian` function in `math.py`: replaced `math.pi` with `np.pi` for consistency with the rest of the file and removed redundant intermediate variable `gauss_distr`. Hope this helps!

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes minor cleanup to `kwave/utils/math.py`: replaces `math.pi` with `np.pi` in `gaussian()` for consistency and inlines the return expression by removing the intermediate `gauss_distr` variable. Two additional unrelated files are also touched — trailing whitespace cleanup in `create_absorption_variables.py` and a line-reformatting in `kspace_solver.py` — neither of which is mentioned in the PR description.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are non-functional cleanup with no risk to correctness.

The core change (math.pi → np.pi, inlined return) is functionally identical. The `import math` is still needed for `math.sqrt` elsewhere in the file, so no dead import is introduced. The kspace_solver.py reformatting stays within the project's 140-char limit. No logic, behaviour, or interface is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| kwave/utils/math.py | Replaced `math.pi` with `np.pi` in `gaussian()` and inlined the return expression; no functional change. `import math` is correctly retained (still used for `math.sqrt` at line 176). |
| kwave/solvers/kspace_solver.py | Multi-line pressure equation reformatted to a single line (~135 chars, within the project's 140-char limit); no functional change. |
| kwave/kWaveSimulation_helper/create_absorption_variables.py | Trailing whitespace removed from docstring lines and newline added at end of file; purely cosmetic cleanup. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["gaussian(x, mean, variance, magnitude)"] --> B{magnitude is None?}
    B -- Yes --> C["magnitude = (2 * np.pi * variance) ** -0.5\n(was math.pi)"]
    B -- No --> D["Use provided magnitude"]
    C --> E["return magnitude * exp(-((x - mean)^2) / (2 * variance))\n(inlined, was gauss_distr)"]
    D --> E
```

<sub>Reviews (1): Last reviewed commit: ["clean up gaussian function, use np.pi an..."](https://github.com/waltsims/k-wave-python/commit/5e183e90911dde85a57f6131077c0ea3825c1abc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30721861)</sub>

<!-- /greptile_comment -->