### PR TITLE
Fix #501: voxel_plot swapped x and z axes

### DIFF
--- a/kwave/utils/plot.py
+++ b/kwave/utils/plot.py
@@ -35,9 +35,9 @@ def voxel_plot(mat, axis_tight=False, color=(1, 1, 0.4), transparency=0.8):
 
     if not axis_tight:
         sz = mat.shape
-        ax.set_xlim([0.5, sz[2] + 0.5])
+        ax.set_xlim([0.5, sz[0] + 0.5])
         ax.set_ylim([0.5, sz[1] + 0.5])
-        ax.set_zlim([0.5, sz[0] + 0.5])
+        ax.set_zlim([0.5, sz[2] + 0.5])
 
     # Show the plot
     plt.show()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from kwave.utils.filters import apply_filter, extract_amp_phase, spect
 from kwave.utils.interp import get_bli
 from kwave.utils.mapgen import fit_power_law_params, power_law_kramers_kronig
 from kwave.utils.matrix import gradient_fd, num_dim, resize, trim_zeros
+from kwave.utils.plot import voxel_plot
 from kwave.utils.signals import add_noise, gradient_spect, tone_burst
 from tests.matlab_test_data_collectors.python_testers.utils.record_reader import TestRecordReader
 
@@ -418,3 +419,20 @@ def test_trim_zeros():
         mat_trimmed, ind = trim_zeros(mat)
 
     # TODO: generalize to N-D case
+
+
+def test_voxel_plot_axis_limits_match_input_shape():
+    """Regression for #501: x/y/z axis limits must follow input array shape (not be swapped)."""
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
+    import matplotlib.pyplot as plt
+
+    mat = np.zeros((4, 8, 12), dtype=np.float64)
+    mat[1:3, 2:6, 3:9] = 1.0
+    voxel_plot(mat)
+    ax = plt.gcf().axes[0]
+    assert ax.get_xlim() == (0.5, 4.5)
+    assert ax.get_ylim() == (0.5, 8.5)
+    assert ax.get_zlim() == (0.5, 12.5)
+    plt.close("all")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,12 @@
 import os
 from pathlib import Path
 
+import matplotlib
+
+# Select a non-interactive backend before any module imports pyplot (test_voxel_plot_*
+# below relies on this — kwave.utils.plot imports matplotlib.pyplot at module load).
+matplotlib.use("Agg")
+
 import numpy as np
 import pytest
 
@@ -423,9 +429,6 @@ def test_trim_zeros():
 
 def test_voxel_plot_axis_limits_match_input_shape():
     """Regression for #501: x/y/z axis limits must follow input array shape (not be swapped)."""
-    import matplotlib
-
-    matplotlib.use("Agg", force=True)
     import matplotlib.pyplot as plt
 
     mat = np.zeros((4, 8, 12), dtype=np.float64)


### PR DESCRIPTION
## Summary

- Fixes #501. `voxel_plot` in `kwave/utils/plot.py` was using `sz[2]` for the x-axis limit and `sz[0]` for the z-axis limit, which mirrored the rendered output relative to the input array's first and last dimensions (and relative to MATLAB k-Wave's `voxelPlot`).
- Now `set_xlim/ylim/zlim` use `sz[0]/sz[1]/sz[2]` (the fix the issue reporter suggested).
- Added a regression test in `tests/test_utils.py` that calls `voxel_plot` on a `(4, 8, 12)` array (asymmetric so a swap is visible) and asserts each axis limit follows the corresponding shape dim.

## Test plan

- [x] New test `test_voxel_plot_axis_limits_match_input_shape` passes locally
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the swapped x/z axis limits in `voxel_plot` — the old code mapped `sz[2]` to xlim and `sz[0]` to zlim, mirroring the output relative to the input array's first and last dimensions. The fix swaps them back so each axis limit follows the corresponding shape dimension, matching MATLAB k-Wave's `voxelPlot` behavior.

- **`kwave/utils/plot.py`**: Two-line swap restoring `set_xlim` → `sz[0]` and `set_zlim` → `sz[2]`.
- **`tests/test_utils.py`**: `matplotlib.use("Agg")` moved to module level (before `kwave.utils.plot` is imported, which itself imports `matplotlib.pyplot`), and a new regression test asserts each axis limit against the expected shape dimension using an asymmetric `(4, 8, 12)` array.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal two-line swap that corrects a long-standing axis-mapping bug, backed by a targeted regression test.

The fix is isolated to two lines in voxel_plot, the logic is straightforward and directly matches the MATLAB reference implementation, and the new test uses an asymmetric array that would fail on the old code, confirming the correction.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| kwave/utils/plot.py | Minimal, correct two-line swap: xlim now uses sz[0] and zlim now uses sz[2], fixing the previously mirrored axis limits. |
| tests/test_utils.py | Adds module-level Agg backend setup and a regression test with an asymmetric array that directly asserts each axis limit; covers the fix thoroughly. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["voxel_plot(mat)"] --> B["mat.shape → sz"]
    B --> C{axis_tight?}
    C -- "False (default)" --> D["set_xlim([0.5, sz[0]+0.5])"]
    D --> E["set_ylim([0.5, sz[1]+0.5])"]
    E --> F["set_zlim([0.5, sz[2]+0.5])"]
    C -- "True" --> G["skip axis limit setup"]
```

<sub>Reviews (2): Last reviewed commit: ["Set matplotlib Agg backend at module lev..."](https://github.com/waltsims/k-wave-python/commit/57ebec70b27d96ace7cfb2de180b9cd8fcdabac1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32449481)</sub>

<!-- /greptile_comment -->