### PR TITLE
Bump BINARY_VERSION to v1.4.1 (sm_120 / Blackwell)

### DIFF
--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import platform
+import warnings
 from pathlib import Path
 from typing import List
 from urllib.request import urlretrieve
@@ -19,6 +20,18 @@ PLATFORM = platform.system().lower()
 
 if PLATFORM not in ["linux", "windows", "darwin"]:
     raise NotImplementedError(f"k-wave-python is currently unsupported on this operating system: {PLATFORM}.")
+
+# darwin C++ binary is arm64-only; universal2 coverage tracked for v0.6.5
+DARWIN_BINARY_ARCH = "arm64"
+_darwin_unsupported = PLATFORM == "darwin" and platform.machine() != DARWIN_BINARY_ARCH
+if _darwin_unsupported:
+    warnings.warn(
+        f"k-wave-python's macOS C++ binary is {DARWIN_BINARY_ARCH}-only. "
+        f"Detected {platform.machine()} — the C++ backend (backend='cpp') will not run on this machine. "
+        "Use backend='python' instead. Universal2 (Intel + Apple Silicon) coverage is tracked for v0.6.5.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
 
 # TODO: install directly in to /bin/ directory system directory is no longer needed
 # TODO: deprecate in 0.5.0
@@ -58,7 +71,11 @@ URL_DICT = {
     },
     "darwin": {
         "cuda": [],
-        "omp": [URL_BASE + f"k-wave-omp-{PLATFORM}/releases/download/{BINARY_VERSION}/{EXECUTABLE_PREFIX}OMP"],
+        "omp": (
+            []
+            if _darwin_unsupported
+            else [URL_BASE + f"k-wave-omp-{PLATFORM}/releases/download/{BINARY_VERSION}/{EXECUTABLE_PREFIX}OMP"]
+        ),
     },
     "windows": {architecture: get_windows_release_urls(architecture) for architecture in ARCHITECTURES},
 }

--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -15,7 +15,10 @@ __version__ = "0.6.1"
 # Constants and Configurations
 URL_BASE = "https://github.com/waltsims/"
 BINARY_VERSION = "v1.4.0"
-PREFIX = f"{URL_BASE}kspaceFirstOrder-{{}}-{{}}/releases/download/{BINARY_VERSION}/"
+# Windows OMP build switched compiler/OpenMP/FFT stack in v1.4.0 and now needs different
+# runtime DLLs than v1.3.0 ships; pin windows OMP to v1.3.0 until the build packages its
+# own DLLs (or links statically). Tracked in kspacefirstorder-unified#14.
+WINDOWS_OMP_VERSION = "v1.3.0"
 PLATFORM = platform.system().lower()
 
 if PLATFORM not in ["linux", "windows", "darwin"]:
@@ -57,11 +60,12 @@ ARCHITECTURES = ["omp", "cuda"]
 
 
 def get_windows_release_urls(architecture: str) -> list:
+    version = WINDOWS_OMP_VERSION if architecture == "omp" else BINARY_VERSION
     specific_filenames = [EXECUTABLE_PREFIX + architecture + ".exe"]
     if architecture == "omp":
         specific_filenames += WINDOWS_DLLS
-    release_urls = [PREFIX.format(architecture.upper(), PLATFORM.lower()) + filename for filename in specific_filenames]
-    return release_urls
+    base = f"{URL_BASE}kspaceFirstOrder-{architecture.upper()}-{PLATFORM.lower()}/releases/download/{version}/"
+    return [base + filename for filename in specific_filenames]
 
 
 URL_DICT = {

--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -13,7 +13,7 @@ __version__ = "0.6.1"
 
 # Constants and Configurations
 URL_BASE = "https://github.com/waltsims/"
-BINARY_VERSION = "v1.3.0"
+BINARY_VERSION = "v1.4.0"
 PREFIX = f"{URL_BASE}kspaceFirstOrder-{{}}-{{}}/releases/download/{BINARY_VERSION}/"
 PLATFORM = platform.system().lower()
 
@@ -53,12 +53,12 @@ def get_windows_release_urls(architecture: str) -> list:
 
 URL_DICT = {
     "linux": {
-        "cuda": [URL_BASE + f"kspaceFirstOrder-CUDA-{PLATFORM}/releases/download/v1.3.1/{EXECUTABLE_PREFIX}CUDA"],
+        "cuda": [URL_BASE + f"kspaceFirstOrder-CUDA-{PLATFORM}/releases/download/{BINARY_VERSION}/{EXECUTABLE_PREFIX}CUDA"],
         "omp": [URL_BASE + f"kspaceFirstOrder-OMP-{PLATFORM}/releases/download/{BINARY_VERSION}/{EXECUTABLE_PREFIX}OMP"],
     },
     "darwin": {
         "cuda": [],
-        "omp": [URL_BASE + f"k-wave-omp-{PLATFORM}/releases/download/v0.3.0rc3/{EXECUTABLE_PREFIX}OMP"],
+        "omp": [URL_BASE + f"k-wave-omp-{PLATFORM}/releases/download/{BINARY_VERSION}/{EXECUTABLE_PREFIX}OMP"],
     },
     "windows": {architecture: get_windows_release_urls(architecture) for architecture in ARCHITECTURES},
 }

--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -11,15 +11,20 @@ from urllib.request import urlretrieve
 
 # Test installation with:
 # python3 -m pip install -i https://test.pypi.org/simple/ --extra-index-url=https://pypi.org/simple/ k-Wave-python==0.3.0
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 # Constants and Configurations
 URL_BASE = "https://github.com/waltsims/"
-BINARY_VERSION = "v1.4.0"
-# Windows OMP build switched compiler/OpenMP/FFT stack in v1.4.0 and now needs different
-# runtime DLLs than v1.3.0 ships; pin windows OMP to v1.3.0 until the build packages its
-# own DLLs (or links statically). Tracked in kspacefirstorder-unified#14.
+BINARY_VERSION = "v1.4.1"
+# Pin both Windows binaries to v1.3.0. v1.4.x windows builds switched compiler /
+# OpenMP / FFT / CUDA runtime stacks and neither v1.4.x release ships its runtime
+# DLLs (cufft, cudart, vcomp, vcruntime140_1, fftw3f, etc.). v1.3.0 binaries are
+# self-contained with their Intel-era DLL bundle (listed in WINDOWS_DLLS below,
+# downloaded with the OMP request and used by both .exe files since they share
+# kwave/bin/windows/). OMP DLL bundling is fixed in kspacefirstorder-unified#14
+# (awaiting validation); CUDA DLL bundling is tracked in kspacefirstorder-unified#17.
 WINDOWS_OMP_VERSION = "v1.3.0"
+WINDOWS_CUDA_VERSION = "v1.3.0"
 PLATFORM = platform.system().lower()
 
 if PLATFORM not in ["linux", "windows", "darwin"]:
@@ -61,7 +66,7 @@ ARCHITECTURES = ["omp", "cuda"]
 
 
 def get_windows_release_urls(architecture: str) -> list:
-    version = WINDOWS_OMP_VERSION if architecture == "omp" else BINARY_VERSION
+    version = WINDOWS_OMP_VERSION if architecture == "omp" else WINDOWS_CUDA_VERSION
     specific_filenames = [EXECUTABLE_PREFIX + architecture + ".exe"]
     if architecture == "omp":
         specific_filenames += WINDOWS_DLLS
@@ -77,9 +82,7 @@ URL_DICT = {
     "darwin": {
         "cuda": [],
         "omp": (
-            []
-            if _darwin_unsupported
-            else [URL_BASE + f"k-wave-omp-{PLATFORM}/releases/download/{BINARY_VERSION}/{EXECUTABLE_PREFIX}OMP"]
+            [] if _darwin_unsupported else [URL_BASE + f"k-wave-omp-{PLATFORM}/releases/download/{BINARY_VERSION}/{EXECUTABLE_PREFIX}OMP"]
         ),
     },
     "windows": {architecture: get_windows_release_urls(architecture) for architecture in ARCHITECTURES},

--- a/plans/release-strategy.md
+++ b/plans/release-strategy.md
@@ -11,8 +11,10 @@ This release strategy brings the unified solver architecture to fruition.
 | **0.5.0** | Finalize master/main | Stabilize current codebase |
 | **0.6.0** | Python Solver + Unified API + Deprecation | Python solver, `kspaceFirstOrder()` kwargs, Future warnings |
 | **0.6.1** | C-order + Examples + Docs | C-order migration, 29 examples ported, 47 parity tests, docs cleanup |
-| **0.6.2** | Tier 2 Features + Examples | Time-reversal, rect sensors, sound_speed_ref, port Tier 2 examples |
-| **0.6.3** | Axisymmetric Support | Axisymmetric solver in new API, port AS examples |
+| **0.6.2** | Binary refresh (sm_120 / Blackwell) | Bump URL pins to upstream v1.4.0 binaries with NVIDIA Blackwell support; closes #656, #622 |
+| **0.6.3** | Tier 2 Features + Examples | Time-reversal, rect sensors, sound_speed_ref, port Tier 2 examples |
+| **0.6.4** | Axisymmetric Support | Axisymmetric solver in new API, port AS examples |
+| **0.6.5** | Broader Darwin coverage | Universal2 (arm64 + x86_64) OpenMP binary; restores Intel Mac support |
 | **0.7.0** | CLI (`kwp`) | Command-line interface for running simulations |
 | **1.0.0** | Clean Release | Remove deprecated code. Simple, readable, fast. |
 | **2.0.0** | Performance & Scale | nanobind CUDA, MPI, Devito, multi-GPU |
@@ -153,7 +155,30 @@ Combined release: C-order migration, example restructure, parity tests, docs cle
 - macOS C++ hint in executor.py (scoped to linker errors)
 - Deleted: Makefile, Dockerfile, run_examples.py, notebook pipeline, dead CI workflows
 
-### v0.6.2 — Tier 2 Features + Examples
+### v0.6.2 — Binary refresh (sm_120 / Blackwell)
+
+**Goal:** Ship `kwave/__init__.py` URL pins that point at the v1.4.0 upstream binaries (sm_120 / Blackwell support). This is a thin release: no Python-side code changes, just pin bumps and a CHANGELOG entry.
+
+**Background:** The unified build pipeline (`kspacefirstorder-unified` @ `02026d05`) produced 5 binary artifacts on 2026-05-16. CUDA archs now include `sm_75;80;86;87;89;90;90a;100;120`. The 5-mirror release flow is itself being retired — see waltsims/kspacefirstorder-unified#13 for the consolidation that obviates a manual runbook.
+
+**Release sequencing (do in order):**
+1. **Tag `v1.4.0` on `kspacefirstorder-unified` @ `02026d05`** — provenance pointer ("this SHA produced the v1.4.0 binaries"). Diff vs current HEAD is doc-only.
+2. **Tag `v1.4.0` on each of the 5 mirror repos** with the corresponding artifact:
+   - `kspaceFirstOrder-CUDA-linux` ← `kspaceFirstOrder-cuda-linux-13.0.0/kspaceFirstOrder-CUDA`
+   - `kspaceFirstOrder-CUDA-windows` ← `kspaceFirstOrder-cuda-windows-13.0.0/kspaceFirstOrder-CUDA.exe`
+   - `kspaceFirstOrder-OMP-linux` ← `kspaceFirstOrder-openmp-linux-ubuntu-latest/kspaceFirstOrder-OMP`
+   - `kspaceFirstOrder-OMP-windows` ← `kspaceFirstOrder-openmp-windows-windows-latest/kspaceFirstOrder-OMP.exe`
+   - `k-wave-omp-darwin` ← `kspaceFirstOrder-openmp-darwin-macos-latest/kspaceFirstOrder-OMP` (arm64-only — see v0.6.5)
+3. In `kwave/__init__.py`, collapse the per-platform version pins (`v1.3.0`, `v1.3.1`, `v0.3.0rc3`) into a single `BINARY_VERSION = "v1.4.0"` used by all five URLs. Open the k-wave-python PR.
+4. Verify on a real Blackwell GPU (cc @aconesac or Brno team for RTX 5070 Ti).
+5. Close issues [#656](https://github.com/waltsims/k-wave-python/issues/656) and [#622](https://github.com/waltsims/k-wave-python/issues/622) on release.
+6. **Bonus close for [#661](https://github.com/waltsims/k-wave-python/issues/661) (macOS HDF5 ABI):** the new darwin OMP binary links `libhdf5.320.dylib` (current Homebrew ABI) — verified with `strings` on the artifact. If a current-Homebrew macOS smoke test runs clean, close #661 referencing the v1.4.0 `k-wave-omp-darwin` release.
+
+**Out of scope:** Darwin x86_64 (Intel Mac) coverage — the v1.4.0 OMP-darwin binary is arm64-only, which is a regression vs. older Intel-era releases. Tracked separately in v0.6.5.
+
+---
+
+### v0.6.3 — Tier 2 Features + Examples
 
 **Goal:** Add solver features needed by Tier 2 examples, port those examples.
 
@@ -174,9 +199,27 @@ Combined release: C-order migration, example restructure, parity tests, docs cle
 - Remove unused MATLAB collector infrastructure if parity tests replace it
 - Audit `kWaveSimulation_helper/` — delete helpers superseded by `kspaceFirstOrder()`
 
-### v0.6.3 — Axisymmetric Support
+### v0.6.4 — Axisymmetric Support
 
 Axisymmetric = dimensionality reduction (3D→2D or 2D→1D). Not a separate solver — wrapper around `kspaceFirstOrder()` with radial symmetry terms added to the wave equation.
+
+---
+
+### v0.6.5 — Broader Darwin coverage (Intel + Apple Silicon)
+
+**Goal:** Restore Intel Mac support for the OpenMP binary. The v1.4.0 release shipped a Mach-O `arm64`-only OMP binary (`kspaceFirstOrder-OMP` in `k-wave-omp-darwin` v1.4.0), which excludes every Intel Mac. Pre-2020 hardware is still the majority of macOS users in academic settings, and even on newer Apple Silicon machines x86_64 coverage is useful for Rosetta-only third-party stacks.
+
+**Decision: ship a universal2 binary (arm64 + x86_64) — not two separate per-arch binaries.** Doubles the file size (~300 KB → ~600 KB, negligible) and avoids a per-arch download-selection step in `kwave/__init__.py`. The build flow already runs on `macos-latest` (Apple Silicon GitHub runners); switching to a universal build is a one-line CMake change plus a `libomp` install for both arches.
+
+**Tasks:**
+1. **Build path:** Add `-DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"` to the macOS leg of `ci-multi-platform.yml` in the unified repo, and ensure the Homebrew install step pulls a `libomp` that has both slices (Homebrew bottles are per-arch — may need `lipo` to combine, or build OMP from source).
+2. **Verify:** `lipo -info kspaceFirstOrder-OMP` should report both `x86_64 arm64`. Smoke test on both an Apple Silicon Mac (native) and an Intel Mac (or `arch -x86_64` on AS via Rosetta).
+3. **Release:** Tag `v1.4.1` (or whatever the next binary release is) on `k-wave-omp-darwin` with the universal binary, then bump `BINARY_VERSION` in `kwave/__init__.py`.
+4. **No Python code changes** are needed — the existing `PLATFORM == "darwin"` branch in `kwave/__init__.py` doesn't distinguish architecture; a universal binary is consumed exactly the same way.
+
+**Future Mac topics (post-1.0, separate releases):**
+- **CUDA on macOS:** Not feasible — Apple dropped NVIDIA driver support after macOS 10.13. The `darwin/cuda` slot in `URL_DICT` will stay empty indefinitely.
+- **Metal / MPS backend for the Python solver:** Would unlock Apple Silicon GPU acceleration for the `backend="python"` path via something like `mlx` or PyTorch's MPS. Scope is the Python solver, not the C++ binary — best fit is the v2.x performance phase.
 
 ---
 
@@ -298,8 +341,10 @@ result = kspaceFirstOrder(kgrid, medium, source, sensor,
 1. ~~v0.5.0~~ ✅ Stabilize master
 2. ~~v0.6.0~~ ✅ Python solver + unified API + deprecations
 3. ~~v0.6.1~~ ✅ C-order + examples + docs cleanup
-4. **Next:** v0.6.2 — Tier 2 features + examples
-5. **Then:** v0.6.3 — Axisymmetric support
-6. **Then:** v0.7.0 — CLI (`kwp`)
-7. **Then:** v1.0.0 — Clean release (delete deprecated code)
-8. **Post-1.0:** Performance & scale based on profiling
+4. **Next:** v0.6.2 — Binary refresh (sm_120 / Blackwell)
+5. **Then:** v0.6.3 — Tier 2 features + examples
+6. **Then:** v0.6.4 — Axisymmetric support
+7. **Then:** v0.6.5 — Broader Darwin coverage (universal2 OMP)
+8. **Then:** v0.7.0 — CLI (`kwp`)
+9. **Then:** v1.0.0 — Clean release (delete deprecated code)
+10. **Post-1.0:** Performance & scale based on profiling

--- a/plans/release-strategy.md
+++ b/plans/release-strategy.md
@@ -157,30 +157,30 @@ Combined release: C-order migration, example restructure, parity tests, docs cle
 
 ### v0.6.2 — Binary refresh (sm_120 / Blackwell)
 
-**Goal:** Ship `kwave/__init__.py` URL pins that point at the v1.4.0 upstream binaries (sm_120 / Blackwell support). This is a thin release: no Python-side code changes, just pin bumps and a CHANGELOG entry.
+**Goal:** Ship `kwave/__init__.py` URL pins that point at fixed upstream binaries with sm_120 / Blackwell support, the macOS HDF5 ABI refresh, and the macOS fast-math fix.
 
-**Background:** The unified build pipeline (`kspacefirstorder-unified` @ `02026d05`) produced 5 binary artifacts on 2026-05-16. CUDA archs now include `sm_75;80;86;87;89;90;90a;100;120`. The 5-mirror release flow is itself being retired — see waltsims/kspacefirstorder-unified#13 for the consolidation that obviates a manual runbook.
+**What actually shipped (retrospective):** v1.4.0 had to be revoked due to packaging regressions and a numerical bug. v0.6.2 ships against **v1.4.1** instead. Summary:
 
-**Release sequencing (do in order):**
-1. **Tag `v1.4.0` on `kspacefirstorder-unified` @ `02026d05`** — provenance pointer ("this SHA produced the v1.4.0 binaries"). Diff vs current HEAD is doc-only.
-2. **Tag `v1.4.0` on each of the 5 mirror repos** with the corresponding artifact:
-   - `kspaceFirstOrder-CUDA-linux` ← `kspaceFirstOrder-cuda-linux-13.0.0/kspaceFirstOrder-CUDA`
-   - `kspaceFirstOrder-CUDA-windows` ← `kspaceFirstOrder-cuda-windows-13.0.0/kspaceFirstOrder-CUDA.exe`
-   - `kspaceFirstOrder-OMP-linux` ← `kspaceFirstOrder-openmp-linux-ubuntu-latest/kspaceFirstOrder-OMP`
-   - `kspaceFirstOrder-OMP-windows` ← `kspaceFirstOrder-openmp-windows-windows-latest/kspaceFirstOrder-OMP.exe`
-   - `k-wave-omp-darwin` ← `kspaceFirstOrder-openmp-darwin-macos-latest/kspaceFirstOrder-OMP` (arm64-only — see v0.6.5)
-3. In `kwave/__init__.py`, collapse the per-platform version pins (`v1.3.0`, `v1.3.1`, `v0.3.0rc3`) into a single `BINARY_VERSION = "v1.4.0"` used by all five URLs. Open the k-wave-python PR.
-4. Verify on a real Blackwell GPU (cc @aconesac or Brno team for RTX 5070 Ti).
-5. Close issues [#656](https://github.com/waltsims/k-wave-python/issues/656) and [#622](https://github.com/waltsims/k-wave-python/issues/622) on release.
-6. **Bonus close for [#661](https://github.com/waltsims/k-wave-python/issues/661) (macOS HDF5 ABI):** the new darwin OMP binary links `libhdf5.320.dylib` (current Homebrew ABI) — verified with `strings` on the artifact. If a current-Homebrew macOS smoke test runs clean, close #661 referencing the v1.4.0 `k-wave-omp-darwin` release.
+- **Linux binaries** — `v1.4.1` rebuilt with static CUDA + cufft + FFTW + libstdc++ on ubuntu-22.04 (glibc 2.35 floor), restoring the plug-and-play property the legacy Makefile build had. Permanent regression guard added via `scripts/check-linux-binary-deps.sh` in the unified repo. Fixed in [kspacefirstorder-unified#15](https://github.com/waltsims/kspacefirstorder-unified/issues/15) and [#16](https://github.com/waltsims/kspacefirstorder-unified/pull/16).
+- **macOS OMP** — `v1.4.1` picks up the fast-math fix ([k-wave-omp-darwin#4](https://github.com/waltsims/k-wave-omp-darwin/pull/4)) that prevents NaNs in absorbing-media simulations on arm64. ABI refresh (`libhdf5.320.dylib`) preserved from v1.4.0; closes [#661](https://github.com/waltsims/k-wave-python/issues/661).
+- **Windows OMP + CUDA** — both pinned to **v1.3.0** for this release. v1.4.x windows builds switched compiler/OpenMP/FFT/CUDA-runtime stacks but neither bundles its runtime DLLs. v1.3.0 binaries are self-contained with the Intel-era DLL bundle (shipped via `WINDOWS_DLLS` with the OMP request and used by both `.exe` files since they share `kwave/bin/windows/`). OMP DLL bundling fix landed in [kspacefirstorder-unified#14](https://github.com/waltsims/kspacefirstorder-unified/issues/14) (awaiting production validation); CUDA bundling tracked in [kspacefirstorder-unified#17](https://github.com/waltsims/kspacefirstorder-unified/issues/17). Pin gets flipped in v0.6.3 once both windows flavors are validated end-to-end.
+- **Chmod fix** — independent fix for `download_binaries` not setting the exec bit on Linux/macOS, surfaced during v0.6.2 validation on Colab ([#741](https://github.com/waltsims/k-wave-python/pull/741)).
+- **Intel Mac guard** — `kwave/__init__.py` now emits a `RuntimeWarning` and skips the darwin OMP download on `darwin` x86_64, since the v1.4.x darwin binary is arm64-only. Universal2 coverage remains tracked in v0.6.5.
 
-**Out of scope:** Darwin x86_64 (Intel Mac) coverage — the v1.4.0 OMP-darwin binary is arm64-only, which is a regression vs. older Intel-era releases. Tracked separately in v0.6.5.
+**Closes:** [#622](https://github.com/waltsims/k-wave-python/issues/622), [#656](https://github.com/waltsims/k-wave-python/issues/656), [#661](https://github.com/waltsims/k-wave-python/issues/661), [#738](https://github.com/waltsims/k-wave-python/issues/738), [#740](https://github.com/waltsims/k-wave-python/issues/740).
+
+**Out of scope:** Darwin x86_64 (Intel Mac) coverage — v1.4.x OMP-darwin is arm64-only. Tracked in v0.6.5.
 
 ---
 
-### v0.6.3 — Tier 2 Features + Examples
+### v0.6.3 — Tier 2 Features + Examples + Windows binary pin flips
 
-**Goal:** Add solver features needed by Tier 2 examples, port those examples.
+**Goal:** Add solver features needed by Tier 2 examples, port those examples, and flip the Windows binary pins to v1.4.x once both flavors are validated.
+
+**Windows binary pin flips (carried over from v0.6.2):**
+- **Validate `v1.4.1` windows-OMP** end-to-end on a Windows machine (smoke + small simulation). Bundle landed in [kspacefirstorder-unified#14](https://github.com/waltsims/kspacefirstorder-unified/issues/14); CI smoke passes; runtime sim not yet confirmed.
+- **Fix `v1.4.x` windows-CUDA DLL packaging** in [kspacefirstorder-unified#17](https://github.com/waltsims/kspacefirstorder-unified/issues/17) — same DLL-bundling pattern as windows-omp, plus CUDA runtime DLLs (`cudart64_*.dll`, `cufft64_*.dll`) from `$env:CUDA_PATH\bin`.
+- Once both validated: drop `WINDOWS_OMP_VERSION` + `WINDOWS_CUDA_VERSION` pins in `kwave/__init__.py` (both use `BINARY_VERSION`). Likely also: refactor `WINDOWS_DLLS` into per-architecture lists since OMP and CUDA need slightly different MSVC redist + runtime deps.
 
 **Features to add:**
 - **Time-reversal reconstruction** — needed by PR examples (`pr_2D_TR_*`, `pr_3D_TR_*`)
@@ -220,6 +220,20 @@ Axisymmetric = dimensionality reduction (3D→2D or 2D→1D). Not a separate sol
 **Future Mac topics (post-1.0, separate releases):**
 - **CUDA on macOS:** Not feasible — Apple dropped NVIDIA driver support after macOS 10.13. The `darwin/cuda` slot in `URL_DICT` will stay empty indefinitely.
 - **Metal / MPS backend for the Python solver:** Would unlock Apple Silicon GPU acceleration for the `backend="python"` path via something like `mlx` or PyTorch's MPS. Scope is the Python solver, not the C++ binary — best fit is the v2.x performance phase.
+
+---
+
+## Binary distribution maintenance (no fixed version)
+
+Work on the upstream binary side that doesn't need its own k-wave-python release — it gets picked up by whatever version bump happens to be in flight.
+
+### Mirror consolidation (kspacefirstorder-unified#13)
+
+Collapse the 5 per-platform mirror repos (`kspaceFirstOrder-{CUDA,OMP}-{linux,windows}` + `k-wave-omp-darwin`) into the unified repo. Each cross-cutting change currently lands ~2-3× (proven by v1.4.0 / v1.4.1 taking ~12 PRs across repos); the consolidation retires that overhead. Cross-linked from k-wave-python#738 — flip `URL_DICT` to point at unified once the consolidation lands. Best fit for v1.5.0 or alongside whichever release first benefits.
+
+### Static-link Windows binaries (v1.5 follow-up)
+
+The v0.6.2 ship used the **bundle** approach for Windows OMP (DLLs alongside the .exe) because static-linking on Windows MSVC is more complex (`/MT` for CRT, vcpkg static port for FFTW, `VCOMP140` static linking is awkward, may need LLVM OpenMP). The Linux fix in unified#15 already uses static linking; Windows should follow once the broader v1.5 static-linking discipline is in scope. Track alongside mirror consolidation since both are "tidy up the binary pipeline" work.
 
 ---
 


### PR DESCRIPTION
## Summary

- Bumps `BINARY_VERSION` to `v1.4.1` — the rebuilt static-linked Linux binaries + fast-math-fixed darwin binary published from [kspacefirstorder-unified#16](https://github.com/waltsims/kspacefirstorder-unified/pull/16).
- Bumps `__version__` to `0.6.2`.
- Keeps `WINDOWS_OMP_VERSION="v1.3.0"` pin — the new v1.4.1 OMP-windows release ships its own DLL bundle but the consumer flip is a discrete v0.6.3 one-liner once we've validated the bundle in production.

## Picked up via this version bump

- **#656 / #622** — NVIDIA Blackwell (sm_120) support. v1.4.1 ships CUDA binaries with arch list `75;80;86;87;89;90;90a;100;120`. Validated by @aconesac on RTX 5060 Laptop (sm_120, CUDA 13) and via Colab T4 (sm_75, CUDA 13.0 runtime).
- **#661** — macOS HDF5 ABI mismatch. v1.4.1 darwin binary links `libhdf5.320.dylib`. Confirmed on M1 install (`otool -L`).
- **#740** — `download_binaries` doesn't set the exec bit on Linux/macOS (fixed independently in [#741](https://github.com/waltsims/k-wave-python/pull/741), merged to master and pulled in via merge).
- **kspacefirstorder-unified#15** — Linux binaries broken on glibc<2.38 / required dynamic CUDA+FFTW. Fixed in unified PR #16 by restoring static linking + pinning Linux CI runner to ubuntu-22.04 (glibc 2.35 floor). Permanent regression guard added via `check-linux-binary-deps.sh`.
- **kspacefirstorder-unified#14** — Windows OMP runtime DLL deps. The v1.4.1 OMP-windows release now bundles MSVC + vcpkg runtime DLLs; consumer pin flip deferred to v0.6.3.

## Validation evidence

- Colab T4 (Ubuntu 22.04, glibc 2.35, CUDA 13.0): `CUDA backend OK shape: (302,), max abs: 0.067452`
- Local Linux (this dev box): full Python → C++/OMP → Python sim, same numerical result
- M1 Mac: clean venv install, `otool -L` confirms `libhdf5.320.dylib` linkage
- aconesac RTX 5060: `--version` + 3D simulation, `CUDA code arch: 12.0`

## Outstanding

- Awaiting `release-on-tag.yml` publish of v1.4.1 to the mirror repos before final CI run on this PR — until then the urlretrieve in `import kwave` 404s against the not-yet-published assets.
- v1.4.0 releases on all 4 mirrors marked **REVOKED (see v1.4.1)**, flipped to prerelease, with explanation in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `BINARY_VERSION` to `v1.4.1` (adding NVIDIA Blackwell sm_120 support and a macOS HDF5 ABI refresh) and increments `__version__` to `0.6.2`. Windows binaries are intentionally held at `v1.3.0` via new `WINDOWS_OMP_VERSION`/`WINDOWS_CUDA_VERSION` pins while runtime DLL bundling for the new compiler stack is validated.

- **Intel Mac guard** — `_darwin_unsupported` is set when `platform.machine() != \"arm64\"` on macOS; a `RuntimeWarning` is emitted and the darwin OMP download URL is replaced with an empty list, preventing a silent `exec format error` at binary invocation.
- **Linux CUDA URL** — previously hard-coded to `v1.3.1`, now tracks `BINARY_VERSION` so both Linux CUDA and OMP move together.
- **Roadmap** updated to renumber milestones and add a v0.6.5 entry for universal2 (Intel + Apple Silicon) darwin binary coverage.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changed files are narrow and the logic is correct.

Both files are narrow: __init__.py touches only constants and the darwin download guard, and release-strategy.md is documentation. The Windows pin separation avoids regressing existing users, the Linux CUDA URL correctly moves from a stale v1.3.1 hardcode to BINARY_VERSION, and the arm64 check prevents a silent crash on Intel Macs. No logic paths are deleted or restructured.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| kwave/__init__.py | Bumps __version__ to 0.6.2 and BINARY_VERSION to v1.4.1; pins Windows to v1.3.0 via separate WINDOWS_OMP_VERSION/WINDOWS_CUDA_VERSION constants; adds Intel Mac (x86_64 darwin) RuntimeWarning and skips OMP download on that arch; fixes Linux CUDA URL which was previously hard-coded to v1.3.1. |
| plans/release-strategy.md | Roadmap updated: v0.6.2 is now the binary refresh, previous tier-2 features milestone shifted to v0.6.3, axisymmetric to v0.6.4, and a new v0.6.5 entry added for universal2 darwin coverage. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[import kwave] --> B{PLATFORM}
    B -- linux --> C[BINARY_VERSION v1.4.1]
    B -- darwin --> D{platform.machine arm64?}
    B -- windows --> E[WINDOWS_OMP v1.3.0 / WINDOWS_CUDA v1.3.0]
    B -- other --> FAIL[raise NotImplementedError]
    D -- yes --> G[darwin omp URL set to v1.4.1 release]
    D -- no --> H[Emit RuntimeWarning / darwin omp URL is empty list]
    C --> I[Linux OMP + CUDA URLs both use v1.4.1]
    E --> J[Windows OMP exe + DLLs from v1.3.0 / CUDA exe from v1.3.0]
    I --> K{binaries_present?}
    G --> K
    H --> K2[binaries_present returns True / no download]
    J --> K
    K -- yes --> DONE[import complete]
    K -- no --> L[install_binaries / download + chmod + write metadata]
    L --> DONE
    K2 --> DONE
```

<sub>Reviews (7): Last reviewed commit: ["Update release strategy with v0.6.2 retr..."](https://github.com/waltsims/k-wave-python/commit/92fd493abab813dfe57a5763528ed36790867564) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32478204)</sub>

<!-- /greptile_comment -->