### PR TITLE
docs: document Blackwell (sm 12.0) GPU support in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 [![Documentation Status](https://readthedocs.org/projects/k-wave-python/badge/?version=latest)](https://k-wave-python.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/waltsims/k-wave-python/graph/badge.svg?token=6ofwtPiDNG)](https://codecov.io/gh/waltsims/k-wave-python)
 
-A Python implementation of [k-Wave](http://www.k-wave.org/) — an acoustics toolbox for time-domain simulation of acoustic wave fields. Includes a pure NumPy/CuPy solver (`backend="python"`) and an interface to the pre-compiled k-Wave C++ binaries (`backend="cpp"`) with NVIDIA GPU support from Maxwell through Blackwell (sm 5.0–9.0a, sm 12.0).
+A Python implementation of [k-Wave](http://www.k-wave.org/) — an acoustics toolbox for time-domain simulation of acoustic wave fields. Includes a pure NumPy/CuPy solver (`backend="python"`, supports any CUDA-capable GPU) and an interface to the pre-compiled k-Wave C++ binaries (`backend="cpp"`) with NVIDIA GPU support for compute capability 7.5 (Turing) and newer — covers every consumer/datacenter GPU since 2018, including all shipping Blackwell variants (B200/GB200, B300/GB300, Jetson Thor, RTX 50xx, RTX PRO 6000 Blackwell, GB10/DGX Spark).
 
 ## Mission
 
@@ -35,6 +35,16 @@ Or with pip:
 ```bash
 pip install k-wave-python
 ```
+
+### Older GPUs (Maxwell, Pascal, Volta)
+
+The `backend="cpp"` binaries shipped in v0.6.3+ require compute capability 7.5 (Turing) or newer. CUDA Toolkit 13.0 removed offline-compilation support for older architectures, so the following hardware is not covered by the bundled binaries:
+
+- **Maxwell** (GTX 9xx, Titan X Maxwell, Tesla M-series, Jetson Nano)
+- **Pascal** (GTX 10xx, P100, P40, Titan X(p)/Xp, Jetson TX2)
+- **Volta** (V100, Titan V, Quadro GV100, Jetson AGX Xavier)
+
+Use `backend="python"` instead (NumPy/CuPy works on every CUDA-capable GPU), or build the C++ backend from source against CUDA Toolkit 12.x.
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 [![Documentation Status](https://readthedocs.org/projects/k-wave-python/badge/?version=latest)](https://k-wave-python.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/waltsims/k-wave-python/graph/badge.svg?token=6ofwtPiDNG)](https://codecov.io/gh/waltsims/k-wave-python)
 
-A Python implementation of [k-Wave](http://www.k-wave.org/) — an acoustics toolbox for time-domain simulation of acoustic wave fields. Includes a pure NumPy/CuPy solver (`backend="python"`) and an interface to the pre-compiled k-Wave C++ binaries (`backend="cpp"`) with NVIDIA GPU support (sm 5.0–9.0a).
+A Python implementation of [k-Wave](http://www.k-wave.org/) — an acoustics toolbox for time-domain simulation of acoustic wave fields. Includes a pure NumPy/CuPy solver (`backend="python"`) and an interface to the pre-compiled k-Wave C++ binaries (`backend="cpp"`) with NVIDIA GPU support from Maxwell through Blackwell (sm 5.0–9.0a, sm 12.0).
 
 ## Mission
 


### PR DESCRIPTION
## Summary
- README claimed NVIDIA support as sm 5.0–9.0a (Maxwell→Hopper), but v0.6.2 pinned the bundled binaries to v1.4.1 which adds sm 12.0 (Blackwell)
- Update the support range in `docs/README.md:7` so RTX 50-series / Blackwell users know the project covers their hardware

## Test plan
- [ ] Visual check that the rendered README on the PR page reads cleanly
- [ ] Confirm sm 12.0 is the only addition vs. the pre-edit line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `docs/README.md` to accurately document the NVIDIA GPU compute-capability support range for the bundled `backend="cpp"` binaries, replacing the outdated "sm 5.0–9.0a" claim and adding a migration note for users with Maxwell/Pascal/Volta hardware.

- The intro line now pins the minimum to cc 7.5 (Turing) and enumerates all shipping Blackwell variants (B200/GB200, B300/GB300, Jetson Thor, RTX 50xx, RTX PRO 6000 Blackwell, GB10/DGX Spark); the CUDA 13.0 offline-compilation-removal claim is factually correct per NVIDIA release notes.
- A new \"Older GPUs\" subsection correctly lists Maxwell, Pascal, and Volta hardware as excluded from the bundled binaries and offers `backend=\"python\"` or a source build as alternatives, but it cites \"v0.6.3+\" as the version where the cc 7.5 floor kicks in — whereas `kwave/__init__.py` shows Linux/macOS already use v1.4.1 binaries (cc 7.5+) starting in v0.6.2.

<h3>Confidence Score: 4/5</h3>

The change is documentation-only and safe to merge with a single targeted correction.

The new 'Older GPUs' subsection states the cc 7.5 floor begins in 'v0.6.3+' but kwave/__init__.py shows Linux/macOS already ship v1.4.1 binaries (cc 7.5 minimum) in the currently released v0.6.2. A Linux or macOS user on v0.6.2 with a Pascal or Volta GPU would read this note and incorrectly conclude the restriction does not yet affect them, then be unable to use the bundled binary with no explanation. Correcting the version reference (or adding a platform qualifier) before merge prevents that user confusion.

docs/README.md — the version cited in the 'Older GPUs' subsection needs to match the actual per-platform binary versions in kwave/__init__.py.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/README.md | Describes per-platform binary version as a blanket 'v0.6.3+' when Linux/macOS already use v1.4.1 (cc 7.5+ floor) in v0.6.2; one factual error that could mislead current Linux/macOS users with older GPUs. Blackwell SKU enumeration and CUDA 13.0 offline-compilation-removal claim are both accurate. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects backend] --> B{backend choice}
    B --> |backend='python'| C[NumPy/CuPy — any CUDA GPU]
    B --> |backend='cpp'| D{Check platform & version}
    D --> |Linux/macOS v0.6.2+| E{cc >= 7.5?}
    D --> |Windows v0.6.2| F[v1.3.0 binaries — broader arch support]
    D --> |Windows v0.6.3+| E
    E --> |Yes — Turing/Ampere/Ada/Hopper/Blackwell| G[Run bundled binary]
    E --> |No — Maxwell/Pascal/Volta| H[Fails — use backend='python' or build from source w/ CUDA 12.x]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User selects backend] --> B{backend choice}
    B --> |backend='python'| C[NumPy/CuPy — any CUDA GPU]
    B --> |backend='cpp'| D{Check platform & version}
    D --> |Linux/macOS v0.6.2+| E{cc >= 7.5?}
    D --> |Windows v0.6.2| F[v1.3.0 binaries — broader arch support]
    D --> |Windows v0.6.3+| E
    E --> |Yes — Turing/Ampere/Ada/Hopper/Blackwell| G[Run bundled binary]
    E --> |No — Maxwell/Pascal/Volta| H[Fails — use backend='python' or build from source w/ CUDA 12.x]
```

</a>

<sub>Reviews (4): Last reviewed commit: ["docs: refine GPU support claim to cc 7.5..."](https://github.com/waltsims/k-wave-python/commit/1191e9d8b12f26849dbd2f6343729590c07a0e3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33258556)</sub>

<!-- /greptile_comment -->