### PR TITLE
Fix-forward: rename-on-download + Greptile P1/P2 follow-ups for v0.6.3

### DIFF
--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -45,23 +45,26 @@ BINARY_PATH = Path(__file__).parent / "bin" / PLATFORM
 BINARY_DIR = BINARY_PATH  # add alias for BINARY_PATH for now
 
 
-# Windows runtime DLLs shipped alongside both .exe files in the unified release.
-# Same DLL set works for both backends: the CUDA build's copy is canonical when
-# a shared dep (HDF5/zlib/szip/MSVC CRT) is built with a slightly newer MSVC
-# than the OMP build (per release-on-tag.yml staging logic). FIXME(0.6.3-rc):
-# verify this list against the actual v1.4.2 release asset manifest once
-# kspacefirstorder-unified publishes — names below are derived from the
-# release-on-tag.yml staging step and may need a final-mile sync.
+# Windows runtime DLLs shipped alongside both .exe files in the unified v1.4.2
+# release. The full bundle is downloaded for either backend selection because we
+# don't know at install time which the user will invoke. Verified against the
+# v1.4.2 release asset manifest (21 DLLs).
 WINDOWS_DLLS = [
-    # CUDA runtime (CUDA 13.0)
+    # CUDA runtime (CUDA 13.0 — used by the CUDA backend)
     "cudart64_13.dll",
     "cufft64_12.dll",
-    # HDF5 + szip + zlib (from vcpkg, used by both backends)
+    # FFTW3 (used by the OMP backend)
+    "fftw3.dll",
+    "fftw3f.dll",
+    "fftw3l.dll",
+    # HDF5 + szip + zlib (from vcpkg; used by both backends)
     "aec.dll",
     "hdf5.dll",
     "hdf5_hl.dll",
     "szip.dll",
     "zlib1.dll",
+    # OpenMP runtime (used by the OMP backend)
+    "vcomp140.dll",
     # MSVC CRT (Concurrency Runtime + C++ stdlib + C runtime)
     "concrt140.dll",
     "msvcp140.dll",

--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -83,29 +83,25 @@ ARCHITECTURES = ["omp", "cuda"]
 
 
 def _platform_binary_url(platform_name: str, architecture: str) -> list:
-    """Return the URL list for a given backend on the given platform.
+    """URLs for a backend on a given platform from the unified v1.4.2+ release.
 
-    Takes ``platform_name`` explicitly rather than reading the module-level
-    ``PLATFORM`` so ``URL_DICT`` is correct for every OS key, not just the
-    current host's.
+    Takes ``platform_name`` explicitly so ``URL_DICT`` is correct for every OS
+    key, not just the host's. ``_darwin_unsupported`` only suppresses URLs
+    when actually running on darwin — building ``URL_DICT["darwin"]`` from a
+    Linux host still yields the canonical darwin asset URL.
     """
-    if platform_name == "darwin":
-        # _darwin_unsupported is only meaningful when actually running on
-        # darwin; building URL_DICT["darwin"] from a Linux host should still
-        # produce the canonical darwin asset URL.
-        if architecture == "cuda" or (platform_name == PLATFORM and _darwin_unsupported):
-            return []
-        return [_UNIFIED_RELEASE_URL + f"{EXECUTABLE_PREFIX}OMP-darwin"]
-    if platform_name == "linux":
-        suffix = "CUDA-linux" if architecture == "cuda" else "OMP-linux"
-        return [_UNIFIED_RELEASE_URL + EXECUTABLE_PREFIX + suffix]
-    # Windows: .exe + (only for OMP) the shared runtime DLL bundle. Both
-    # backends use the same DLLs, so we attach them once to OMP and skip
-    # them on the CUDA entry — otherwise install_binaries would download
-    # all 21 DLLs twice (once per backend) on first install.
-    exe_suffix = "CUDA-windows.exe" if architecture == "cuda" else "OMP-windows.exe"
-    dll_urls = [_UNIFIED_RELEASE_URL + dll for dll in WINDOWS_DLLS] if architecture == "omp" else []
-    return [_UNIFIED_RELEASE_URL + EXECUTABLE_PREFIX + exe_suffix] + dll_urls
+    if architecture == "cuda" and platform_name == "darwin":
+        return []
+    if platform_name == "darwin" and platform_name == PLATFORM and _darwin_unsupported:
+        return []
+    backend = "CUDA" if architecture == "cuda" else "OMP"
+    ext = ".exe" if platform_name == "windows" else ""
+    exe_url = f"{_UNIFIED_RELEASE_URL}{EXECUTABLE_PREFIX}{backend}-{platform_name}{ext}"
+    # Shared runtime DLLs ship with the OMP entry only — both backends find
+    # them at the same BINARY_PATH, so attaching to both would download the
+    # full 21-DLL bundle twice on first install.
+    dll_urls = [_UNIFIED_RELEASE_URL + dll for dll in WINDOWS_DLLS] if platform_name == "windows" and architecture == "omp" else []
+    return [exe_url] + dll_urls
 
 
 URL_DICT = {plat: {arch: _platform_binary_url(plat, arch) for arch in ARCHITECTURES} for plat in ["linux", "darwin", "windows"]}
@@ -114,26 +110,16 @@ URL_DICT = {plat: {arch: _platform_binary_url(plat, arch) for arch in ARCHITECTU
 def _local_filename(asset_name: str) -> str:
     """Map a unified-release asset name to the local install filename.
 
-    The unified release v1.4.2+ tags platform binaries with explicit
-    suffixes (``kspaceFirstOrder-CUDA-linux``, ``kspaceFirstOrder-OMP-windows.exe``)
-    to disambiguate them in the asset list. Consumer code (``_resolve_binary_path``,
-    tests, ``BINARY_PATH``-relative lookups) expects the bare backend name
-    (``kspaceFirstOrder-CUDA``, ``kspaceFirstOrder-OMP``, plus ``.exe`` on Windows).
-    Strip the platform suffix so the downloaded file lands at the path the
-    rest of the package expects.
-
-    Non-prefixed assets (DLLs, etc.) pass through unchanged.
+    The unified release tags platform binaries with the platform name
+    (e.g. ``kspaceFirstOrder-CUDA-linux``, ``kspaceFirstOrder-OMP-windows.exe``)
+    to disambiguate them in the GitHub asset list. Consumer code expects the
+    bare backend name (``kspaceFirstOrder-CUDA``, ``kspaceFirstOrder-OMP``,
+    plus ``.exe`` on Windows). Non-prefixed assets (DLLs, etc.) pass through.
     """
     if not asset_name.startswith(EXECUTABLE_PREFIX):
-        return asset_name  # DLL or other shared asset — ship under its own name
-    rest = asset_name[len(EXECUTABLE_PREFIX) :]  # e.g. "CUDA-linux" or "OMP-windows.exe"
-    backend, _, suffix = rest.partition("-")
-    if not suffix:
-        return asset_name  # already bare (no platform tag)
-    # Preserve any file extension carried in the platform suffix (".exe" on Windows)
-    ext = ""
-    if "." in suffix:
-        ext = "." + suffix.split(".", 1)[1]
+        return asset_name
+    backend = asset_name.split("-", 2)[1]
+    ext = ".exe" if asset_name.endswith(".exe") else ""
     return f"{EXECUTABLE_PREFIX}{backend}{ext}"
 
 

--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -11,20 +11,17 @@ from urllib.request import urlretrieve
 
 # Test installation with:
 # python3 -m pip install -i https://test.pypi.org/simple/ --extra-index-url=https://pypi.org/simple/ k-Wave-python==0.3.0
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 # Constants and Configurations
 URL_BASE = "https://github.com/waltsims/"
-BINARY_VERSION = "v1.4.1"
-# Pin both Windows binaries to v1.3.0. v1.4.x windows builds switched compiler /
-# OpenMP / FFT / CUDA runtime stacks and neither v1.4.x release ships its runtime
-# DLLs (cufft, cudart, vcomp, vcruntime140_1, fftw3f, etc.). v1.3.0 binaries are
-# self-contained with their Intel-era DLL bundle (listed in WINDOWS_DLLS below,
-# downloaded with the OMP request and used by both .exe files since they share
-# kwave/bin/windows/). OMP DLL bundling is fixed in kspacefirstorder-unified#14
-# (awaiting validation); CUDA DLL bundling is tracked in kspacefirstorder-unified#17.
-WINDOWS_OMP_VERSION = "v1.3.0"
-WINDOWS_CUDA_VERSION = "v1.3.0"
+BINARY_VERSION = "v1.4.2"
+# Single unified release hosts every platform binary + Windows runtime DLL
+# (consolidated from 5 mirror repos in v1.4.2; see kspacefirstorder-unified#13).
+# One version pin, one set of assets, one source-tree SHA. CUDA binary covers
+# compute capability 7.5+ (Turing through every Blackwell variant: B200/GB200,
+# B300/GB300, Jetson Thor, RTX 50xx, RTX PRO 6000 Blackwell, GB10/DGX Spark).
+_UNIFIED_RELEASE_URL = f"{URL_BASE}kspacefirstorder-unified/releases/download/{BINARY_VERSION}/"
 PLATFORM = platform.system().lower()
 
 if PLATFORM not in ["linux", "windows", "darwin"]:
@@ -48,45 +45,55 @@ BINARY_PATH = Path(__file__).parent / "bin" / PLATFORM
 BINARY_DIR = BINARY_PATH  # add alias for BINARY_PATH for now
 
 
+# Windows runtime DLLs shipped alongside both .exe files in the unified release.
+# Same DLL set works for both backends: the CUDA build's copy is canonical when
+# a shared dep (HDF5/zlib/szip/MSVC CRT) is built with a slightly newer MSVC
+# than the OMP build (per release-on-tag.yml staging logic). FIXME(0.6.3-rc):
+# verify this list against the actual v1.4.2 release asset manifest once
+# kspacefirstorder-unified publishes — names below are derived from the
+# release-on-tag.yml staging step and may need a final-mile sync.
 WINDOWS_DLLS = [
-    "cufft64_10.dll",
+    # CUDA runtime (CUDA 13.0)
+    "cudart64_13.dll",
+    "cufft64_12.dll",
+    # HDF5 + szip + zlib (from vcpkg, used by both backends)
+    "aec.dll",
     "hdf5.dll",
     "hdf5_hl.dll",
-    "libiomp5md.dll",
-    "libmmd.dll",
-    "msvcp140.dll",
-    "svml_dispmd.dll",
     "szip.dll",
+    "zlib1.dll",
+    # MSVC CRT (Concurrency Runtime + C++ stdlib + C runtime)
+    "concrt140.dll",
+    "msvcp140.dll",
+    "msvcp140_1.dll",
+    "msvcp140_2.dll",
+    "msvcp140_atomic_wait.dll",
+    "msvcp140_codecvt_ids.dll",
+    "vccorlib140.dll",
     "vcruntime140.dll",
-    "zlib.dll",
+    "vcruntime140_1.dll",
+    "vcruntime140_threads.dll",
 ]
 
 EXECUTABLE_PREFIX = "kspaceFirstOrder-"
 ARCHITECTURES = ["omp", "cuda"]
 
 
-def get_windows_release_urls(architecture: str) -> list:
-    version = WINDOWS_OMP_VERSION if architecture == "omp" else WINDOWS_CUDA_VERSION
-    specific_filenames = [EXECUTABLE_PREFIX + architecture + ".exe"]
-    if architecture == "omp":
-        specific_filenames += WINDOWS_DLLS
-    base = f"{URL_BASE}kspaceFirstOrder-{architecture.upper()}-{PLATFORM.lower()}/releases/download/{version}/"
-    return [base + filename for filename in specific_filenames]
+def _platform_binary_url(architecture: str) -> list:
+    """Return the URL list for a given backend on the current platform."""
+    if PLATFORM == "darwin":
+        if _darwin_unsupported or architecture == "cuda":
+            return []
+        return [_UNIFIED_RELEASE_URL + f"{EXECUTABLE_PREFIX}OMP-darwin"]
+    if PLATFORM == "linux":
+        suffix = "CUDA-linux" if architecture == "cuda" else "OMP-linux"
+        return [_UNIFIED_RELEASE_URL + EXECUTABLE_PREFIX + suffix]
+    # Windows: the .exe plus the shared runtime DLL bundle
+    exe_suffix = "CUDA-windows.exe" if architecture == "cuda" else "OMP-windows.exe"
+    return [_UNIFIED_RELEASE_URL + EXECUTABLE_PREFIX + exe_suffix] + [_UNIFIED_RELEASE_URL + dll for dll in WINDOWS_DLLS]
 
 
-URL_DICT = {
-    "linux": {
-        "cuda": [URL_BASE + f"kspaceFirstOrder-CUDA-{PLATFORM}/releases/download/{BINARY_VERSION}/{EXECUTABLE_PREFIX}CUDA"],
-        "omp": [URL_BASE + f"kspaceFirstOrder-OMP-{PLATFORM}/releases/download/{BINARY_VERSION}/{EXECUTABLE_PREFIX}OMP"],
-    },
-    "darwin": {
-        "cuda": [],
-        "omp": (
-            [] if _darwin_unsupported else [URL_BASE + f"k-wave-omp-{PLATFORM}/releases/download/{BINARY_VERSION}/{EXECUTABLE_PREFIX}OMP"]
-        ),
-    },
-    "windows": {architecture: get_windows_release_urls(architecture) for architecture in ARCHITECTURES},
-}
+URL_DICT = {os: {arch: _platform_binary_url(arch) for arch in ARCHITECTURES} for os in ["linux", "darwin", "windows"]}
 
 
 def _hash_file(filepath: str) -> str:

--- a/kwave/__init__.py
+++ b/kwave/__init__.py
@@ -82,21 +82,59 @@ EXECUTABLE_PREFIX = "kspaceFirstOrder-"
 ARCHITECTURES = ["omp", "cuda"]
 
 
-def _platform_binary_url(architecture: str) -> list:
-    """Return the URL list for a given backend on the current platform."""
-    if PLATFORM == "darwin":
-        if _darwin_unsupported or architecture == "cuda":
+def _platform_binary_url(platform_name: str, architecture: str) -> list:
+    """Return the URL list for a given backend on the given platform.
+
+    Takes ``platform_name`` explicitly rather than reading the module-level
+    ``PLATFORM`` so ``URL_DICT`` is correct for every OS key, not just the
+    current host's.
+    """
+    if platform_name == "darwin":
+        # _darwin_unsupported is only meaningful when actually running on
+        # darwin; building URL_DICT["darwin"] from a Linux host should still
+        # produce the canonical darwin asset URL.
+        if architecture == "cuda" or (platform_name == PLATFORM and _darwin_unsupported):
             return []
         return [_UNIFIED_RELEASE_URL + f"{EXECUTABLE_PREFIX}OMP-darwin"]
-    if PLATFORM == "linux":
+    if platform_name == "linux":
         suffix = "CUDA-linux" if architecture == "cuda" else "OMP-linux"
         return [_UNIFIED_RELEASE_URL + EXECUTABLE_PREFIX + suffix]
-    # Windows: the .exe plus the shared runtime DLL bundle
+    # Windows: .exe + (only for OMP) the shared runtime DLL bundle. Both
+    # backends use the same DLLs, so we attach them once to OMP and skip
+    # them on the CUDA entry — otherwise install_binaries would download
+    # all 21 DLLs twice (once per backend) on first install.
     exe_suffix = "CUDA-windows.exe" if architecture == "cuda" else "OMP-windows.exe"
-    return [_UNIFIED_RELEASE_URL + EXECUTABLE_PREFIX + exe_suffix] + [_UNIFIED_RELEASE_URL + dll for dll in WINDOWS_DLLS]
+    dll_urls = [_UNIFIED_RELEASE_URL + dll for dll in WINDOWS_DLLS] if architecture == "omp" else []
+    return [_UNIFIED_RELEASE_URL + EXECUTABLE_PREFIX + exe_suffix] + dll_urls
 
 
-URL_DICT = {os: {arch: _platform_binary_url(arch) for arch in ARCHITECTURES} for os in ["linux", "darwin", "windows"]}
+URL_DICT = {plat: {arch: _platform_binary_url(plat, arch) for arch in ARCHITECTURES} for plat in ["linux", "darwin", "windows"]}
+
+
+def _local_filename(asset_name: str) -> str:
+    """Map a unified-release asset name to the local install filename.
+
+    The unified release v1.4.2+ tags platform binaries with explicit
+    suffixes (``kspaceFirstOrder-CUDA-linux``, ``kspaceFirstOrder-OMP-windows.exe``)
+    to disambiguate them in the asset list. Consumer code (``_resolve_binary_path``,
+    tests, ``BINARY_PATH``-relative lookups) expects the bare backend name
+    (``kspaceFirstOrder-CUDA``, ``kspaceFirstOrder-OMP``, plus ``.exe`` on Windows).
+    Strip the platform suffix so the downloaded file lands at the path the
+    rest of the package expects.
+
+    Non-prefixed assets (DLLs, etc.) pass through unchanged.
+    """
+    if not asset_name.startswith(EXECUTABLE_PREFIX):
+        return asset_name  # DLL or other shared asset — ship under its own name
+    rest = asset_name[len(EXECUTABLE_PREFIX) :]  # e.g. "CUDA-linux" or "OMP-windows.exe"
+    backend, _, suffix = rest.partition("-")
+    if not suffix:
+        return asset_name  # already bare (no platform tag)
+    # Preserve any file extension carried in the platform suffix (".exe" on Windows)
+    ext = ""
+    if "." in suffix:
+        ext = "." + suffix.split(".", 1)[1]
+    return f"{EXECUTABLE_PREFIX}{backend}{ext}"
 
 
 def _hash_file(filepath: str) -> str:
@@ -182,8 +220,8 @@ def binaries_present() -> bool:
     """
     binary_list = []
     for binary_type in ARCHITECTURES:
-        for binary_name in URL_DICT[PLATFORM][binary_type]:
-            binary_list.append((binary_name.split("/")[-1], binary_type))
+        for url in URL_DICT[PLATFORM][binary_type]:
+            binary_list.append((_local_filename(url.split("/")[-1]), binary_type))
 
     missing_binaries: List[str] = []
 
@@ -226,10 +264,12 @@ def download_binaries(system_os: str, bin_type: str):
 
     """
     for url in URL_DICT[system_os][bin_type]:
-        # Extract the file name from the GitHub release URL
-        binary_version, filename = url.split("/")[-2:]
+        # Extract the asset name from the GitHub release URL, then map it to
+        # the local install filename consumer code expects (see _local_filename).
+        binary_version, asset_name = url.split("/")[-2:]
+        filename = _local_filename(asset_name)
 
-        logging.log(logging.INFO, f"Downloading {filename} to {BINARY_PATH}...")
+        logging.log(logging.INFO, f"Downloading {asset_name} -> {filename} in {BINARY_PATH}...")
 
         # Create the directory if it does not yet exist
         os.makedirs(BINARY_PATH, exist_ok=True)

--- a/tests/test__init__.py
+++ b/tests/test__init__.py
@@ -3,6 +3,7 @@ import json
 import os
 import stat
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -50,9 +51,15 @@ def test_download_sets_executable_bit(tmp_path, monkeypatch):
     monkeypatch.setattr(kwave, "BINARY_PATH", tmp_path)
 
     test_url = next(urls[0] for urls in kwave.URL_DICT[kwave.PLATFORM].values() if urls)
-    filename = test_url.rsplit("/", 1)[-1]
+    created = {}
 
     def fake_urlretrieve(url, dest):
+        # Capture the actual destination chosen by download_binaries instead
+        # of re-deriving it from the URL — the unified release v1.4.2+ tags
+        # assets with a platform suffix (e.g. -linux) that the package
+        # strips when computing the local install filename, so URL-tail
+        # inference is no longer correct (and never should have been).
+        created["dest"] = dest
         with open(dest, "wb") as f:
             f.write(b"fake-binary-payload")
         os.chmod(dest, 0o644)
@@ -62,7 +69,7 @@ def test_download_sets_executable_bit(tmp_path, monkeypatch):
 
     kwave.download_binaries(kwave.PLATFORM, "test")
 
-    binary_filepath = tmp_path / filename
+    binary_filepath = Path(created["dest"])
     assert binary_filepath.exists()
     mode = os.stat(binary_filepath).st_mode
     assert mode & stat.S_IXUSR, "owner exec bit not set after download"


### PR DESCRIPTION
## Why this PR

Addresses 4 regressions introduced by the (already-merged-and-then-reverted-in-spirit) PR #756. Branch was restored after that merge broke 4 tests on Python 3.12.

## Fixes

### 1. Test-breaker — `FileNotFoundError: Binary not found at kwave/bin/linux/kspaceFirstOrder-CUDA`

The unified release tags platform binaries with explicit suffixes (`kspaceFirstOrder-CUDA-linux`, `-windows.exe`, `-darwin`). The download code used `url.split('/')[-1]` as the local filename, so the file landed at `…/kspaceFirstOrder-CUDA-linux` while `_resolve_binary_path` / `_is_binary_present` / the test fixtures all look for the bare `…/kspaceFirstOrder-CUDA`.

**Fix:** introduce `_local_filename()` that strips the platform suffix when mapping asset name → local install filename. Used consistently in `download_binaries` and `binaries_present` so download and presence-check agree. DLLs and other non-`kspaceFirstOrder-` assets pass through unchanged.

8-case self-test in commit description; smoke test on Linux confirms binaries land at the expected paths.

### 2. Greptile P1 — `URL_DICT` had host-platform URLs under every OS key

`_platform_binary_url(architecture)` was reading the module-level `PLATFORM` global. On a Linux host, `URL_DICT["darwin"]` and `URL_DICT["windows"]` both pointed at Linux assets. Silent footgun for any cross-platform caller.

**Fix:** take `platform_name` as a required argument; build URL_DICT by passing the iteration variable.

### 3. Greptile P2 — DLLs downloaded twice on first install

Both `URL_DICT["windows"]["omp"]` and `URL_DICT["windows"]["cuda"]` carried the full 21-DLL bundle, so `install_binaries` requested every DLL twice.

**Fix:** attach DLLs only to the OMP entry (matches the old code's intent — the DLLs are shared and both backends find them via the same `BINARY_PATH`).

### 4. Greptile P2 — loop variable `os` shadowed the stdlib `os` import

**Fix:** rename to `plat`.

## Test plan

- [x] `_local_filename` self-test: 8 cases (Linux/Windows/Darwin × CUDA/OMP + DLLs) — all green
- [x] `URL_DICT` inspection: every (plat, arch) key produces correct platform-specific URLs
- [x] Local import: `python -c "import kwave"` downloads `kspaceFirstOrder-CUDA` and `kspaceFirstOrder-OMP` to `kwave/bin/linux/` (bare names, as consumer code expects)
- [ ] Full CI matrix green on this PR
- [ ] Greptile zero-issue re-review

## After this merges

k-wave-python master is healthy on v1.4.2 binaries. Then we can cut v0.6.3.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four regressions introduced by the now-reverted PR #756 that caused test failures on Python 3.12 due to mismatched binary filenames after switching to the unified v1.4.2 release. The changes are surgical and well-reasoned, with each fix directly addressing a documented regression.

- Adds `_local_filename()` to strip the platform suffix (`-linux`, `-windows.exe`, `-darwin`) from unified-release asset names so that downloaded binaries land at the bare paths consumer code expects (`kspaceFirstOrder-CUDA`, not `kspaceFirstOrder-CUDA-linux`); used consistently in both `download_binaries` and `binaries_present`.
- Fixes `_platform_binary_url` to accept `platform_name` as an explicit argument so `URL_DICT` contains correct per-OS URLs regardless of the host platform, and attaches the Windows DLL bundle only to the OMP entry to prevent double-download on first install.
- Updates `test_download_sets_executable_bit` to capture the actual `urlretrieve` destination via a closure, making it robust to the suffix-stripping logic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four targeted regressions are correctly addressed and the download/presence-check paths are now consistent.

The core changes are correct and internally consistent; the only gap is a test fixture that seeds a binary at the raw asset-name path rather than the local-filename-processed path, leaving one healing-path scenario untested against the real filename convention.

tests/test__init__.py — test_existing_non_executable_binary_is_healed seeds its binary at the raw URL tail rather than the _local_filename-processed path.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| kwave/__init__.py | Adds _local_filename() to strip platform suffixes, fixes _platform_binary_url to accept explicit platform_name, removes duplicate DLL attachment for CUDA, renames loop variable os→plat. Logic is consistent and correct. |
| tests/test__init__.py | test_download_sets_executable_bit correctly captures dest via closure. test_existing_non_executable_binary_is_healed still derives filename from raw URL tail (with platform suffix) rather than _local_filename, so it seeds and checks a path that doesn't match what binaries_present() would use. |

</details>


</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["import kwave"] --> B["binaries_present()"]
    B --> C["URL_DICT[PLATFORM][arch]"]
    C --> D["url.split('/')[-1] asset_name"]
    D --> E["_local_filename(asset_name)"]
    E --> F{starts with EXECUTABLE_PREFIX?}
    F -- No --> G["pass through (DLLs, etc.)"]
    F -- Yes --> H["split('-',2)[1] backend + .exe if windows"]
    H --> I["kspaceFirstOrder-CUDA or kspaceFirstOrder-OMP"]
    G --> J["_is_binary_present(local_name, arch)"]
    I --> J
    J --> K{exists and hash matches and URL matches?}
    K -- No --> L["install_binaries()"]
    K -- Yes --> M["_ensure_executable()"]
    L --> N["download_binaries(PLATFORM, arch)"]
    N --> O["URL_DICT[os][bin_type] URLs"]
    O --> P["asset_name = url.split('/')[-2:]"]
    P --> Q["filename = _local_filename(asset_name)"]
    Q --> R["urlretrieve(url, BINARY_PATH/filename)"]
    R --> S["_ensure_executable(filepath)"]
    S --> T["_record_binary_metadata(url, filename)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["import kwave"] --> B["binaries_present()"]
    B --> C["URL_DICT[PLATFORM][arch]"]
    C --> D["url.split('/')[-1] asset_name"]
    D --> E["_local_filename(asset_name)"]
    E --> F{starts with EXECUTABLE_PREFIX?}
    F -- No --> G["pass through (DLLs, etc.)"]
    F -- Yes --> H["split('-',2)[1] backend + .exe if windows"]
    H --> I["kspaceFirstOrder-CUDA or kspaceFirstOrder-OMP"]
    G --> J["_is_binary_present(local_name, arch)"]
    I --> J
    J --> K{exists and hash matches and URL matches?}
    K -- No --> L["install_binaries()"]
    K -- Yes --> M["_ensure_executable()"]
    L --> N["download_binaries(PLATFORM, arch)"]
    N --> O["URL_DICT[os][bin_type] URLs"]
    O --> P["asset_name = url.split('/')[-2:]"]
    P --> Q["filename = _local_filename(asset_name)"]
    Q --> R["urlretrieve(url, BINARY_PATH/filename)"]
    R --> S["_ensure_executable(filepath)"]
    S --> T["_record_binary_metadata(url, filename)"]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `kwave/__init__.py`, line 184-187 ([link](https://github.com/waltsims/k-wave-python/blob/a096d3aa832393e751fba13809dff9c256382627/kwave/__init__.py#L184-L187)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead-code branch — `binary_type is None` is never reached**

   `binaries_present()` is the only call-site that feeds values into `_is_binary_present`, and it always passes a value from `ARCHITECTURES` (`"omp"` or `"cuda"`). No caller ever passes `None`, so the guard and its early-return are dead code. This was true before this PR (DLLs were already given the same `binary_type` as their parent backend), but the refactoring here makes it even clearer. The misleading comment `# this is non-kwave windows binary` implies a design that no longer exists and can cause confusion when reading the validation flow.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["test\_\_init\_\_: capture actual urlretrieve..."](https://github.com/waltsims/k-wave-python/commit/e839fc64e8aed1d34b1d5aa3593428a9e5817ad8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38900584)</sub>

<!-- /greptile_comment -->