### PR TITLE
docs: add benchmark results matrix to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Reference runtimes for the 3D scaling benchmark in [`benchmarks/benchmark.py`](.
 |---------|-----------------------|-------------------|-----|------|------|----------|
 | python  | Linux                 | CPU               | —   | —    | —    | —        |
 | python  | Linux                 | NVIDIA GPU        | —   | —    | —    | —        |
-| python  | macOS (Apple Silicon) | CPU               | —   | —    | —    | —        |
+| python  | macOS (Apple Silicon) | CPU               | 81  | —    | —    | Apple M1, 8 GB |
 | python  | Windows               | CPU               | —   | —    | —    | —        |
 | python  | Windows               | NVIDIA GPU        | —   | —    | —    | —        |
 | cpp     | Linux                 | CPU (OMP)         | —   | —    | —    | —        |

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,25 @@ uv run examples/ivp_homogeneous_medium.py
 
 No GPU required — all examples run on CPU with NumPy.
 
+## Benchmarks
+
+Reference runtimes for the 3D scaling benchmark in [`benchmarks/benchmark.py`](../benchmarks/README.md). Values are total elapsed seconds for a single default run (3D initial-value problem, heterogeneous absorbing medium, 1000 timesteps, averaged over 3 repeats).
+
+| Backend | OS                    | Accelerator       | 64³ | 128³ | 256³ | Hardware |
+|---------|-----------------------|-------------------|-----|------|------|----------|
+| python  | Linux                 | CPU               | —   | —    | —    | —        |
+| python  | Linux                 | NVIDIA GPU        | —   | —    | —    | —        |
+| python  | macOS (Apple Silicon) | CPU               | —   | —    | —    | —        |
+| python  | Windows               | CPU               | —   | —    | —    | —        |
+| python  | Windows               | NVIDIA GPU        | —   | —    | —    | —        |
+| cpp     | Linux                 | CPU (OMP)         | —   | —    | —    | —        |
+| cpp     | Linux                 | NVIDIA GPU (CUDA) | —   | —    | —    | —        |
+| cpp     | macOS (Apple Silicon) | CPU (OMP)         | —   | —    | —    | —        |
+| cpp     | Windows               | CPU (OMP)         | —   | —    | —    | —        |
+| cpp     | Windows               | NVIDIA GPU (CUDA) | —   | —    | —    | —        |
+
+Contributions welcome — open a PR filling a row with your k-wave-python version, and (for `cpp` backend) `BINARY_VERSION`. See [`benchmarks/README.md`](../benchmarks/README.md) for the reproducer command.
+
 ## Installation
 
 Using [uv](https://docs.astral.sh/uv/) (recommended):


### PR DESCRIPTION
## Summary

Adds a `## Benchmarks` section to the front-page README (`docs/README.md`) with a 10-row matrix covering `(backend, OS, accelerator)` combinations against three grid sizes: 64³, 128³, 256³.

All cells ship empty (em-dash) as a scaffold. The plan is for contributors to fill rows via follow-up commits on this branch:
- **Magda:** macOS (Apple Silicon), python backend, CPU
- **Farid:** any hardware you have available
- Anyone else with a machine that fits a row

Grid-size columns are drawn from the isotropic sizes in the default `x/y/z_scale_array` in `benchmarks/helpers.py` (indices 0/3/6/9 = 32³/64³/128³/256³, dropped 32³ as too small to be interesting). 512³ was excluded because many workstations OOM.

Rows omitted intentionally:
- `python`/`cpp` + macOS + GPU — no CUDA on macOS.
- `cpp` + Intel Mac + CPU — rare; can be added when someone runs it.

Reproducer command lives in [`benchmarks/README.md`](../benchmarks/README.md); the section links to it.

## Test plan

- [ ] Section renders correctly on GitHub (table alignment, em-dash characters)
- [ ] Section renders correctly on PyPI once the next release ships (`docs/README.md` is the `readme = ` in `pyproject.toml`)
- [ ] Contributors can fill a row without merge conflicts on other rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds benchmark results to the public README. The main changes are:

- A backend, operating system, accelerator, and hardware matrix.
- Runtime columns for 64³, 128³, and 256³ grids.
- An initial Apple M1 result and contribution instructions.

<h3>Confidence Score: 5/5</h3>

The documentation is mergeable after small fixes to the benchmark links and reproduction guidance.

- The matrix dimensions and stated benchmark defaults match the implementation.
- The script link opens a different file than its label names.
- The default reproducer runs large cases that the matrix intentionally excludes.

docs/README.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/README.md | Adds the benchmark matrix and contribution guidance; the benchmark defaults are accurate, but one link is mislabeled and the linked default reproducer runs cases outside the matrix. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fill python/macOS/CPU 64³ benchmar..."](https://github.com/waltsims/k-wave-python/commit/9451b8a70426337c55aa6a3d5df1a1167a2992e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45777333)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->