### PR TITLE
docs: hyphenate time-domain in pyproject.toml description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "k-Wave-python"
 dynamic = ["version"]
-description = "Acoustics toolbox for time domain acoustic and ultrasound simulations in complex and tissue-realistic media."
+description = "Acoustics toolbox for time-domain acoustic and ultrasound simulations in complex and tissue-realistic media."
 readme = "docs/README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## Description
This PR fixes the compound adjective hyphenation for `time-domain` in `pyproject.toml`'s description field.

## Details
Hyphenated `time domain` -> `time-domain` to match standard usage across `docs/README.md` and the rest of the documentation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects compound-adjective hyphenation in package metadata.
- Changes “time domain” to “time-domain” in the `pyproject.toml` project description.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The change only corrects hyphenation in a valid TOML string and introduces no functional, packaging, or security issue.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Updates one metadata description string without affecting packaging syntax or runtime behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: hyphenate time-domain in pyproject..."](https://github.com/waltsims/k-wave-python/commit/7505785b7b8b1551e562de1cf9a7b33c4b9e2a87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46779325)</sub>

<!-- /greptile_comment -->