### PR TITLE
fix(scripts): standardize shebang and clean whitespace in make_docs.sh

### DIFF
--- a/make_docs.sh
+++ b/make_docs.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
- # sphinx-apidoc  -o ./docs -efT $pwd 
- sphinx-build -b html docs docs/_build
+# sphinx-apidoc -o ./docs -efT $pwd
+sphinx-build -b html docs docs/_build


### PR DESCRIPTION
## Description
This PR standardizes the shebang interpreter directive and cleans up leading whitespace in `make_docs.sh`.

## Details
1. Updated shebang (`#! /bin/bash` $\to$ `#!/usr/bin/env bash`).
2. Removed extraneous leading spaces in shell execution commands.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Standardizes the documentation helper script without changing its build behavior.
- Uses `#!/usr/bin/env bash` for portable Bash resolution.
- Removes unnecessary leading whitespace from the Sphinx command and adjacent comment.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the documentation command remains unchanged and no repository workflow depends on an incompatible interpreter path.

The script still invokes the same Sphinx build, while the updated shebang uses a conventional portable Bash lookup and existing documentation workflows do not execute this helper.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| make_docs.sh | The shebang and whitespace cleanup preserve the existing Sphinx documentation build command without introducing a reachable failure. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scripts): standardize shebang and cl..."](https://github.com/waltsims/k-wave-python/commit/e18a1a5517a463123f74df7a71d804d06caae860) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46963333)</sub>

<!-- /greptile_comment -->