### PR TITLE
fix(scripts): pass arguments to pytest in run_tests.sh

### DIFF
--- a/make_docs.sh
+++ b/make_docs.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
- # sphinx-apidoc  -o ./docs -efT $pwd 
- sphinx-build -b html docs docs/_build
+# sphinx-apidoc -o ./docs -efT $pwd
+sphinx-build -b html docs docs/_build

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -8,4 +8,4 @@ docker run -it \
   --volume "$(pwd)":$project_dir_in_container \
   --workdir $project_dir_in_container \
   $image_name \
-  pytest    # run pytest
+  pytest "$@"


### PR DESCRIPTION
## Description
This PR allows passing CLI arguments to `pytest` when running `run_tests.sh`.

## Details
Updated script execution line (`pytest` $\to$ `pytest "$@"`) to forward options (such as specific test file paths or markers).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates local helper scripts:
- Forwards all command-line arguments from `run_tests.sh` to pytest while preserving argument boundaries.
- Standardizes the `make_docs.sh` shebang and whitespace.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The pytest arguments remain individually quoted and are placed correctly after the container command, while the documentation script changes do not alter its build command.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| run_tests.sh | Correctly forwards caller arguments to pytest inside the Docker container using quoted `"$@"`. |
| make_docs.sh | Standardizes the Bash shebang and removes insignificant whitespace without changing documentation-build behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scripts): pass arguments to pytest i..."](https://github.com/waltsims/k-wave-python/commit/16162405fc583c345c6b1b1e1b60848439958993) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46963358)</sub>

<!-- /greptile_comment -->