### PR TITLE
include binary path

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -44,7 +44,11 @@ def run(
     timer: Callable[[], float] = perf_counter,
     memory_reader: Callable[[], float] = current_memory_bytes,
     memory_sampling_interval: float = 0.05,
+    cpp_binary: str | None = None,
 ) -> dict[str, Any]:
+    """
+    Run the benchmark.
+    """
     solver = kspaceFirstOrder if solver is None else solver
     cases = grid_sizes(options)
     if max_cases is not None:
@@ -61,6 +65,11 @@ def run(
         "error_reached": False,
         "error_message": "",
     }
+
+    # If the run() caller provided a cpp_binary override, record it in the saved options
+    if cpp_binary is not None:
+        result["options"]["cpp_binary"] = cpp_binary
+
     if options.report_mem_usage:
         # Probe early so unsupported combinations (e.g. Windows + cpp) fail
         # before any output file is written. cpp probes the sampler class
@@ -103,6 +112,7 @@ def run(
                             pml_size=options.pml_size,
                             pml_inside=options.pml_inside,
                             smooth_p0=False,
+                            binary_path=cpp_binary,
                         )
                         elapsed_time = timer() - start
                     loop_mem_usage = rolling_average(loop_mem_usage, memory_sampler.peak_bytes, loop_num)
@@ -119,6 +129,7 @@ def run(
                         pml_size=options.pml_size,
                         pml_inside=options.pml_inside,
                         smooth_p0=False,
+                        binary_path=cpp_binary,
                     )
                     elapsed_time = timer() - start
                 loop_time = rolling_average(loop_time, elapsed_time, loop_num)
@@ -144,6 +155,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--output-path", type=Path, default=None)
     parser.add_argument("--report-mem-usage", action="store_true")
     parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--cpp-binary", type=str, default=None, help="Path to a custom C++ binary to use for backend=cpp")
     return parser.parse_args()
 
 
@@ -154,6 +166,7 @@ def main() -> int:
         num_averages=args.num_averages,
         number_time_points=args.number_time_points,
         report_mem_usage=args.report_mem_usage,
+        cpp_binary=args.cpp_binary,
     )
     result = run(
         benchmark_options,
@@ -162,6 +175,7 @@ def main() -> int:
         max_cases=args.max_cases,
         output_path=args.output_path,
         quiet=not args.verbose,
+        cpp_binary=args.cpp_binary,
     )
     print(f"Benchmark results saved to {result['output_path']}")
     if result["error_reached"]:

--- a/benchmarks/helpers.py
+++ b/benchmarks/helpers.py
@@ -56,6 +56,7 @@ class BenchmarkOptions:
     pml_size: int = 10
     pml_inside: bool = True
     report_mem_usage: bool = False
+    cpp_binary: str | None = None
 
     def __post_init__(self) -> None:
         if self.data_cast not in {"off", "single"}:


### PR DESCRIPTION
Closes #781 

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a benchmark option and CLI argument for selecting a custom C++ solver binary, records that selection in benchmark metadata, and forwards it to solver execution.
- Extends `BenchmarkOptions` with `cpp_binary`.
- Adds `--cpp-binary` to the benchmark CLI.
- Passes the selected path through native benchmark runs.

<h3>Confidence Score: 4/5</h3>

The programmatic benchmark configuration should be fixed before merging because it can ignore the configured binary and record misleading benchmark provenance.

`BenchmarkOptions.cpp_binary` is serialized as the selected binary, while solver execution instead uses a separately defaulted `run()` argument, allowing the recorded configuration and actual executable to diverge.

**Files Needing Attention:** benchmarks/benchmark.py, benchmarks/helpers.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| benchmarks/benchmark.py | Adds custom-binary parsing, recording, and solver forwarding, but keeps the configured path in two independent parameters that can diverge for programmatic callers. |
| benchmarks/helpers.py | Adds the custom binary path to benchmark configuration and serialized options; this field is not directly used by benchmark execution. |

</details>

<sub>Reviews (1): Last reviewed commit: ["include binary path"](https://github.com/waltsims/k-wave-python/commit/ec8eebbad76ce87cb0da657210997847493cd26b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57889114)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Native solver integration](https://app.greptile.com/private-org-7/-/custom-context/knowledge-base/waltsims/k-wave-python/-/docs/native-solver-integration.md)

<!-- /greptile_comment -->